### PR TITLE
Deprotection logic

### DIFF
--- a/src/TLS/Cryptography/cipher/block_chain.cpp
+++ b/src/TLS/Cryptography/cipher/block_chain.cpp
@@ -73,7 +73,7 @@ ustring pad_message(ustring message) {
 }
 
 
-tls_record AES_CBC_SHA::encrypt(tls_record record) noexcept {
+tls_record AES_CBC_SHA::protect(tls_record record) noexcept {
     auto ctx = hmac(sha1(), server_MAC_key );
     std::array<uint8_t,13> sequence {};
     checked_bigend_write(seqno_server, sequence, 0, 8);
@@ -102,7 +102,7 @@ tls_record AES_CBC_SHA::encrypt(tls_record record) noexcept {
     return record;
 }
 
-tls_record AES_CBC_SHA::decrypt(tls_record record) {
+tls_record AES_CBC_SHA::deprotect(tls_record record) {
 
     if(record.m_contents.size() % 16 != 0 or record.m_contents.size() < 32) {
         throw ssl_error("bad encrypted record length", AlertLevel::fatal, AlertDescription::decrypt_error);

--- a/src/TLS/Cryptography/cipher/block_chain.hpp
+++ b/src/TLS/Cryptography/cipher/block_chain.hpp
@@ -31,8 +31,8 @@ public:
     AES_CBC_SHA();
     
     void set_key_material_12(ustring material) override;
-    tls_record encrypt(tls_record record) noexcept override;
-    tls_record decrypt(tls_record record) override;
+    tls_record protect(tls_record record) noexcept override;
+    tls_record deprotect(tls_record record) override;
 };
 
 } // namespace fbw

--- a/src/TLS/Cryptography/cipher/chacha20poly1305.cpp
+++ b/src/TLS/Cryptography/cipher/chacha20poly1305.cpp
@@ -340,20 +340,20 @@ ustring ChaCha20_Poly1305_ctx::decrypt(ustring ciphertext, ustring additional_da
     return plaintext;
 }
 
-tls_record ChaCha20_Poly1305_tls13::encrypt(tls_record record) noexcept {
+tls_record ChaCha20_Poly1305_tls13::protect(tls_record record) noexcept {
     record = wrap13(std::move(record));
     ustring additional_data = make_additional_13(record.m_contents, TAG_SIZE);
     record.m_contents = ctx.encrypt(std::move(record.m_contents), additional_data);
     return record;
 }
 
-tls_record ChaCha20_Poly1305_tls12::encrypt(tls_record record) noexcept {
+tls_record ChaCha20_Poly1305_tls12::protect(tls_record record) noexcept {
     ustring additional_data = make_additional_12(record, ctx.seqno_server, 0);
     record.m_contents = ctx.encrypt(std::move(record.m_contents), additional_data);
     return record;
 }
 
-tls_record ChaCha20_Poly1305_tls13::decrypt(tls_record record) {
+tls_record ChaCha20_Poly1305_tls13::deprotect(tls_record record) {
     if(record.m_contents.size() < TAG_SIZE) {
         throw ssl_error("short record Poly1305", AlertLevel::fatal, AlertDescription::decrypt_error);
     }
@@ -363,7 +363,7 @@ tls_record ChaCha20_Poly1305_tls13::decrypt(tls_record record) {
     return record;
 }
 
-tls_record ChaCha20_Poly1305_tls12::decrypt(tls_record record) {
+tls_record ChaCha20_Poly1305_tls12::deprotect(tls_record record) {
     if(record.m_contents.size() < TAG_SIZE) {
         throw ssl_error("short record Poly1305", AlertLevel::fatal, AlertDescription::decrypt_error);
     }

--- a/src/TLS/Cryptography/cipher/chacha20poly1305.hpp
+++ b/src/TLS/Cryptography/cipher/chacha20poly1305.hpp
@@ -41,8 +41,8 @@ public:
     void set_server_traffic_key(const ustring& key) override;
     void set_client_traffic_key(const ustring& key) override;
     bool do_key_reset() override;
-    tls_record encrypt(tls_record record) noexcept override;
-    tls_record decrypt(tls_record record) override;
+    tls_record protect(tls_record record) noexcept override;
+    tls_record deprotect(tls_record record) override;
 };
 
 class ChaCha20_Poly1305_tls12 : public cipher_base_tls12 {
@@ -51,8 +51,8 @@ private:
 public:
     ChaCha20_Poly1305_tls12() = default;
     void set_key_material_12(ustring material) override;
-    tls_record encrypt(tls_record record) noexcept override;
-    tls_record decrypt(tls_record record) override;
+    tls_record protect(tls_record record) noexcept override;
+    tls_record deprotect(tls_record record) override;
 };
 
 } // namespace fbw

--- a/src/TLS/Cryptography/cipher/cipher_base.hpp
+++ b/src/TLS/Cryptography/cipher/cipher_base.hpp
@@ -19,8 +19,8 @@ class cipher_base {
     // A cipher is chosen in TLS Handshake Hello.
     // Ciphers share an interface
 public:
-    virtual tls_record encrypt(tls_record record) noexcept = 0;
-    virtual tls_record decrypt(tls_record record) = 0;
+    virtual tls_record protect(tls_record record) noexcept = 0;
+    virtual tls_record deprotect(tls_record record) = 0;
     virtual ~cipher_base() noexcept = default;
 };
 

--- a/src/TLS/Cryptography/cipher/galois_counter.cpp
+++ b/src/TLS/Cryptography/cipher/galois_counter.cpp
@@ -343,7 +343,7 @@ ustring make_additional_12(const tls_record& record, uint64_t sequence_no, size_
     return additional_data;
 }
 
-tls_record AES_128_GCM_SHA256::encrypt(tls_record record) noexcept {
+tls_record AES_128_GCM_SHA256::protect(tls_record record) noexcept {
     ustring additional_data = make_additional_12(record, ctx.seqno_server, 0);
     ustring sequence_no;
     sequence_no.resize(8);
@@ -358,7 +358,7 @@ tls_record AES_128_GCM_SHA256::encrypt(tls_record record) noexcept {
     return record;
 }
 
-tls_record AES_128_GCM_SHA256_tls13::encrypt(tls_record record) noexcept {
+tls_record AES_128_GCM_SHA256_tls13::protect(tls_record record) noexcept {
     record = wrap13(std::move(record));
     ustring additional_data = make_additional_13(record.m_contents, TAG_SIZE);
     ustring sequence_no;
@@ -376,7 +376,7 @@ tls_record AES_128_GCM_SHA256_tls13::encrypt(tls_record record) noexcept {
     return record;
 }
 
-tls_record AES_256_GCM_SHA384::encrypt(tls_record record) noexcept {
+tls_record AES_256_GCM_SHA384::protect(tls_record record) noexcept {
     record = wrap13(std::move(record));
     ustring additional_data = make_additional_13(record.m_contents, TAG_SIZE);
     ustring sequence_no;
@@ -394,7 +394,7 @@ tls_record AES_256_GCM_SHA384::encrypt(tls_record record) noexcept {
     return record;
 }
 
-tls_record AES_128_GCM_SHA256::decrypt(tls_record record) {
+tls_record AES_128_GCM_SHA256::deprotect(tls_record record) {
     if(record.m_contents.size() < TAG_SIZE + sizeof(uint64_t)) [[unlikely]] {
         throw ssl_error("short record IV HMAC", AlertLevel::fatal, AlertDescription::decrypt_error);
     }
@@ -414,7 +414,7 @@ tls_record AES_128_GCM_SHA256::decrypt(tls_record record) {
     return record;
 }
 
-tls_record AES_128_GCM_SHA256_tls13::decrypt(tls_record record) {
+tls_record AES_128_GCM_SHA256_tls13::deprotect(tls_record record) {
     if(record.m_contents.size() < (TAG_SIZE + 1)) [[unlikely]] {
         throw ssl_error("short record IV HMAC", AlertLevel::fatal, AlertDescription::decrypt_error);
     }
@@ -437,7 +437,7 @@ tls_record AES_128_GCM_SHA256_tls13::decrypt(tls_record record) {
     return record;
 }
 
-tls_record AES_256_GCM_SHA384::decrypt(tls_record record) {
+tls_record AES_256_GCM_SHA384::deprotect(tls_record record) {
     if(record.m_contents.size() < (TAG_SIZE + 1)) [[unlikely]] {
         throw ssl_error("record too short for tag and wrap", AlertLevel::fatal, AlertDescription::decrypt_error);
     }

--- a/src/TLS/Cryptography/cipher/galois_counter.hpp
+++ b/src/TLS/Cryptography/cipher/galois_counter.hpp
@@ -38,8 +38,8 @@ class AES_128_GCM_SHA256 : public cipher_base_tls12 {
 public:
     AES_128_GCM_SHA256() = default;
     void set_key_material_12(ustring material) override;
-    tls_record encrypt(tls_record record) noexcept override;
-    tls_record decrypt(tls_record record) override;
+    tls_record protect(tls_record record) noexcept override;
+    tls_record deprotect(tls_record record) override;
 };
 
 class AES_128_GCM_SHA256_tls13 : public cipher_base_tls13 {
@@ -52,8 +52,8 @@ public:
     void set_server_traffic_key(const ustring& key) override;
     void set_client_traffic_key(const ustring& key) override;
     bool do_key_reset() override;
-    tls_record encrypt(tls_record record) noexcept override;
-    tls_record decrypt(tls_record record) override;
+    tls_record protect(tls_record record) noexcept override;
+    tls_record deprotect(tls_record record) override;
 };
 
 class AES_256_GCM_SHA384 : public cipher_base_tls13 {
@@ -66,8 +66,8 @@ public:
     void set_server_traffic_key(const ustring& key) override;
     void set_client_traffic_key(const ustring& key) override;
     bool do_key_reset() override;
-    tls_record encrypt(tls_record record) noexcept override;
-    tls_record decrypt(tls_record record) override;
+    tls_record protect(tls_record record) noexcept override;
+    tls_record deprotect(tls_record record) override;
 };
 
 

--- a/src/TLS/tls_engine.cpp
+++ b/src/TLS/tls_engine.cpp
@@ -80,13 +80,13 @@ HandshakeStage tls_engine::process_net_read(std::queue<packet_timed>& network_ou
                         application_data.append(std::move(record.m_contents));
                         return m_expected_read_record;
                     }
-                    if(m_expected_read_record == HandshakeStage::client_early_data) {
-                        if(!handshake.zero_rtt) {
-                            break;
-                        }
+                    if(m_expected_read_record == HandshakeStage::client_early_data or m_expected_read_record == HandshakeStage::client_handshake_finished) {
                         early_data_received += record.m_contents.size();
                         if(early_data_received > MAX_EARLY_DATA) {
                             throw ssl_error("too much early data", AlertLevel::fatal, AlertDescription::unexpected_message);
+                        }
+                        if(!handshake.zero_rtt) {
+                            break;
                         }
                         application_data.append(std::move(record.m_contents));
                         break;
@@ -228,18 +228,24 @@ tls_record tls_engine::decrypt_record(tls_record record) {
     }
     if(client_cipher_spec) {
         assert(cipher_context);
-        record = cipher_context->decrypt(std::move(record));
-        // try {
-        //    record = cipher_context->decrypt(std::move(record));
-        // } catch(ssl_error& e) {
-        //    if(record.get_type() == Application and 
-        //        m_expected_read_record == HandshakeStage::client_early_data and 
-        //        handshake.server_hello_type == ServerHelloType::diffie_hellman) {
-        //            // client preemptively sent early data we don't have the key to decrypt
-        //            return tls_record(Application);
-        // }
-        //    throw;
-        // }
+        auto encrypted_size = record.m_contents.size();
+        try {
+            record = cipher_context->decrypt(std::move(record));
+        } catch(ssl_error& e) {
+            if(record.get_type() == Application and 
+                m_expected_read_record == HandshakeStage::client_handshake_finished and 
+                handshake.client_hello.parsed_extensions.contains(ExtensionType::early_data) and
+                !handshake.zero_rtt) {
+                    // RFC 8446 4.2.10
+                    //     The server then skips past early data by attempting to deprotect
+                    //     received records using the handshake traffic key, discarding records
+                    //     which fail deprotection up to the configured max_early_data_size
+                    auto blank_record = tls_record(Application);
+                    blank_record.m_contents.resize(encrypted_size);
+                    return blank_record;
+            }
+            throw;
+        }
     }
     return record;
 }
@@ -343,7 +349,7 @@ void tls_engine::client_hello(const ustring& handshake_message) {
     }
     handshake.client_hello_record(handshake_message);
     if(tls_protocol_version == TLS13) {
-        if (handshake.client_hello.parsed_extensions.contains(ExtensionType::early_data)) {
+        if (handshake.zero_rtt) {
             m_expected_read_record = HandshakeStage::client_early_data;
         } else if(handshake.server_hello_type == ServerHelloType::hello_retry) {
             m_expected_read_record = HandshakeStage::client_hello;

--- a/src/TLS/tls_engine.cpp
+++ b/src/TLS/tls_engine.cpp
@@ -230,7 +230,7 @@ tls_record tls_engine::decrypt_record(tls_record record) {
         assert(cipher_context);
         auto encrypted_size = record.m_contents.size();
         try {
-            record = cipher_context->decrypt(std::move(record));
+            record = cipher_context->deprotect(std::move(record));
         } catch(ssl_error& e) {
             if(record.get_type() == Application and 
                 m_expected_read_record == HandshakeStage::client_handshake_finished and 
@@ -270,7 +270,7 @@ void tls_engine::write_record_sync(std::queue<packet_timed>& output, tls_record 
     }
     if(server_cipher_spec and record.get_type() != ChangeCipherSpec) {
         assert(cipher_context);
-        record = cipher_context->encrypt(record);
+        record = cipher_context->protect(record);
     }
     output.push({record.serialise(), timeout});
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -49,7 +49,7 @@
 // refactor TLS::write_buffer usage - also this might handle empty records strangely
 // to test key update mechanism again after changes
 // todo: add RFC references as comments
-// once HTTP/2 and HTTP/1.1 share the same interface, combine perform_hello_sync and read_append_impl_sync
+// once HTTP/2 ready, make session tickets check ALPN
 
 // after a connection is accepted, this is the per-client entry point
 task<void> http_client(std::unique_ptr<fbw::stream> client_stream, bool redirect, connection_token ip_connections, std::string alpn) {


### PR DESCRIPTION
If the server reboots, then it will use a different session ticket master key. Clients may still send those session tickets along with some early data the server can't now encrypt. RFC 8446 4.2.10 lists the server's options for handling session tickets, and the first two are options for this scenario.