### PR TITLE
HTTP/2 WINDOW_UPDATE bugs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
           name: Test session tickets
           command: |
             echo -e "GET / HTTP/1.1\r\nHost: localhost\r\n\r\n" > request.txt
-            cat request.txt | openssl s_client -connect localhost:8443 -tls1_3 -sess_out session.pem
+            cat request.txt | openssl s_client -connect localhost:8443 -tls1_3 -ign_eof -sess_out session.pem
             cat request.txt | openssl s_client -connect localhost:8443 -tls1_3 -sess_in session.pem 2>&1 | grep -q "Reused, TLSv1.3"
 
             # cat request.txt | openssl s_client -connect localhost:8443 -tls1_3 -sess_out session.pem

--- a/makefile
+++ b/makefile
@@ -1,12 +1,12 @@
 # Compiler and flags
 CXX := g++
 #CXX := arm-linux-gnueabihf-g++
-CXXFLAGS := -std=c++23 -Wall -Wno-psabi -MMD -MP -O2 -march=native
+CXXFLAGS := -std=c++23 -Wall -Wno-psabi -MMD -MP #-O2 # -march=native
 LDFLAGS :=
 
 ifeq ($(shell uname -s),Linux)
 # GLIBCXX_3.4.30 does not support armv6
-#	CXXFLAGS += -flto=6 -static
+	CXXFLAGS += -flto=6 -static
     LDFLAGS += # -static-libstdc++ -static-libgcc
 else
  	#CXXFLAGS += -flto

--- a/makefile
+++ b/makefile
@@ -6,7 +6,7 @@ LDFLAGS :=
 
 ifeq ($(shell uname -s),Linux)
 # GLIBCXX_3.4.30 does not support armv6
-	CXXFLAGS += -flto=6 -static
+#	CXXFLAGS += -flto=6 -static
     LDFLAGS += # -static-libstdc++ -static-libgcc
 else
  	#CXXFLAGS += -flto

--- a/src/Application/http_handler.cpp
+++ b/src/Application/http_handler.cpp
@@ -76,7 +76,7 @@ task<stream_result> app_send_body_slice(http_ctx& conn, const std::filesystem::p
     if(t.fail()) {
         co_return stream_result::closed;
     }
-    ustring buffer;
+    std::vector<uint8_t> buffer;
     t.seekg(begin);
     while(t.tellg() != end && !t.eof()) {
         auto next_buffer_size = std::min(FILE_READ_SIZE, ssize_t(end - t.tellg()));

--- a/src/Application/http_handler.cpp
+++ b/src/Application/http_handler.cpp
@@ -7,59 +7,288 @@
 
 #include "../Runtime/task.hpp"
 #include "http_handler.hpp"
+#include "../HTTP/HTTP1_1/HTTP.hpp"
+#include "../HTTP/HTTP1_1/mimemap.hpp"
+#include "../TLS/Cryptography/one_way/keccak.hpp"
+#include <algorithm>
 
 #include "../global.hpp"
 
 namespace fbw {
 
-// handle stream starts when headers have been received
-task<void> application_handler(std::shared_ptr<http_ctx> connection) {
-    assert(connection != nullptr);
-    std::vector<entry_t> request_headers = connection->get_headers();
+std::optional<std::string> find_header(const std::vector<entry_t>& request_headers, std::string header) {
+    auto it = std::find_if(request_headers.begin(), request_headers.end(), [&](const entry_t& entry){ return entry.name == header; });
+    if(it == request_headers.end()) {
+        return std::nullopt;
+    }
+    return it->value;
+}
 
-    auto method_it = std::find_if(request_headers.begin(), request_headers.end(), [](const entry_t& entry){ return entry.name == ":method"; });
-    if(method_it == request_headers.end()) {
-        co_return;
-    }
-    
-    if(method_it->value == "POST") {
-        ustring some_data;
-        do {
-            auto [ res, end ] = co_await connection->append_http_data(some_data);
-            if(res != stream_result::ok) {
-                co_return;
-            }
-            if(!end) {
-                continue;
-            }
-        } while(false);
-    }
-    
+std::string app_error_to_html(std::string error) {
+    std::ostringstream oss;
+    oss << "<!DOCTYPE html>\n"
+        << "<html>\n"
+        << "<head><title>\n" << error << "</title></head>\n"
+        << "\t<body><h1>\n" << error << "</h1></body>\n" 
+        << "</html>";
+    return oss.str();
+}
+
+task<void> send_error(std::shared_ptr<http_ctx> connection, uint32_t status_code, std::string status_message) {
     std::vector<entry_t> send_headers;
-    const std::string message = "<HTML>HELLO WORLD</HTML>";
-    if(method_it == send_headers.end() or method_it->value != "GET") {
-        send_headers.push_back({":status", "500"});
-        send_headers.push_back({"content-length", std::to_string(message.size())});
-        auto res = co_await connection->write_headers(send_headers);
-        if(res != stream_result::ok) {
-            co_return;
-        }
-        auto umessage = to_unsigned(message);
-        std::span<const uint8_t> sp {(uint8_t*)umessage.data(), umessage.size()};
-        co_await connection->write_data(sp);
-        co_return;
-    }
-    send_headers.push_back({":status", "200"});
+    std::string message = app_error_to_html(status_message);
+    send_headers.push_back({":status", std::to_string(status_code)});
     send_headers.push_back({"content-length", std::to_string(message.size())});
     send_headers.push_back({"content-type", "text/html; charset=utf-8"});
+    send_headers.push_back({"server", "FredPi/0.1 (Unix) (Raspbian/Linux)"});
     auto res = co_await connection->write_headers(send_headers);
     if(res != stream_result::ok) {
         co_return;
     }
+    auto umessage = to_unsigned(message);
+    std::span<const uint8_t> sp {umessage};
+    std::cout << "sending error" << std::endl;
+    auto resu = co_await connection->write_data(sp, true);
+    if(resu != stream_result::ok) {
+        co_return;
+    }
+}
+
+std::vector<entry_t> headers_to_send(ssize_t file_size, std::string mime, bool full = true) {
+    auto time = std::time(0);
+    constexpr time_t day = 24*60*60;
+    std::vector<entry_t> out;
+    std::string status_code;
+    if(file_size == 0) {
+        status_code = "204";
+    } else {
+        if(!full) {
+            status_code = "206";
+        } else {
+            status_code = "200";
+        }
+    }
+    out.push_back({":status", status_code});
+    if(file_size != 0) {
+        out.push_back({"content-length", std::to_string(file_size)});
+    }
+    out.push_back({"date", timestring(time)});
+    out.push_back({"expires", timestring(time + day)});
+    out.push_back({"content-type", mime + (mime.substr(0, 4) == "text" ? "; charset=UTF-8" : "")});
+    out.push_back({"server", make_server_name()});
     
-    std::span<const uint8_t> sp {(uint8_t*)message.data(), message.size()};
-    co_await connection->write_data(sp, true);
+    return out;
+}
+
+task<stream_result> app_send_body_slice(std::shared_ptr<http_ctx> conn, const std::filesystem::path& file_path, ssize_t begin, ssize_t end) {
+    std::ifstream t(file_path, std::ifstream::binary);
+    if(t.fail()) {
+        co_return stream_result::closed;
+    }
+    ustring buffer;
+    t.seekg(begin);
+    while(t.tellg() != end && !t.eof()) {
+        auto next_buffer_size = std::min(FILE_READ_SIZE, ssize_t(end - t.tellg()));
+        buffer.resize(next_buffer_size);
+        t.read(reinterpret_cast<char*>(buffer.data()), buffer.size());
+        std::cout << "sending data" << std::endl;
+        auto res = co_await conn->write_data(buffer);
+        if(res != stream_result::ok) [[unlikely]] {
+            co_return res;
+        }
+        assert(t.tellg() <= end);
+    }
+    co_return stream_result::ok;
+}
+
+std::string http1_1_range_header(std::pair<ssize_t, ssize_t> range, ssize_t file_size) {
+    return "Content-Range: bytes " + std::to_string(range.first) + "-" + std::to_string(range.second) + "/" + std::to_string(file_size) + "\r\n\r\n";
+}
+
+// todo: sanitise inputs
+std::pair<ssize_t, ssize_t> app_get_range_bounds(ssize_t file_size, std::pair<ssize_t, ssize_t>& range) {
+    ssize_t begin;
+    ssize_t end;
+    if(range.first == -1) {
+        begin = file_size - range.second;
+        end = file_size;
+        range.first = begin;
+        range.second = end - 1;
+    } else if(range.second == -1) {
+        begin = range.first;
+        end = std::min(ssize_t(file_size), range.first + RANGE_SUGGESTED_SIZE);
+        range.second = end - 1;
+    } else {
+        begin = range.first;
+        end = range.second + 1;
+    }
+
+    if (range.first > range.second or range.second >= file_size) {
+        return {0,0};
+    }
+    assert(end > begin);
+    return {begin, end};
+}
+
+task<void> send_ranged_response(std::shared_ptr<http_ctx> conn, const std::filesystem::path& file_path, ssize_t file_size, std::string mime, std::pair<uint32_t, uint32_t> range,  bool send_body) {
+    if(range.first >= range.second) {
+        co_await send_error(conn, 416, "Range Not Satisfiable");
+        co_return;
+    }
+    auto headers = headers_to_send(range.second - range.first, mime, false);
+    headers.push_back({"accept-ranges", "bytes"});
+    headers.push_back({"content-range", "bytes " + std::to_string(range.first) + "-" + std::to_string(range.second) + "/" + std::to_string(file_size)});
+    auto res = co_await conn->write_headers(headers);
+    if(res != stream_result::ok) {
+        co_return;
+    }
+    if(send_body) {
+        co_await app_send_body_slice(conn, file_path, range.first, range.second);
+    }
     co_return;
+}
+
+task<void> send_multi_ranged_response(std::shared_ptr<http_ctx> conn, const std::filesystem::path& file_path, ssize_t file_size, std::string mime, std::vector<std::pair<ssize_t, ssize_t>> ranges,  bool send_body) {
+    std::array<uint8_t, 28> entropy;
+    randomgen.randgen(entropy);
+    std::string boundary_string;
+    for(unsigned c : entropy) {
+        boundary_string.push_back('A' + c % 26);
+    }
+    
+    std::string mid_bound =  "--" + boundary_string + "\r\nContent-Type: " + mime + "\r\n";
+    std::string end_bound = "--" + boundary_string + "--\r\n";
+
+    auto content_size = 0;
+    for(auto& range : ranges) {
+        auto [begin, end] = app_get_range_bounds(file_size, range);
+        if(begin == 0 and end == 0) {
+            co_await send_error(conn, 416, "Requested Range Not Satisfiable");
+            co_return;
+        }
+        content_size += mid_bound.size();
+        content_size += http1_1_range_header(range, file_size).size();
+        content_size += (end - begin);
+        content_size += std::string("\r\n").size();
+    }
+    content_size += end_bound.size();
+
+    auto headers = headers_to_send(content_size, "multipart/byteranges; boundary=" + boundary_string, false);
+    headers.push_back({"accept-ranges", "bytes"});
+
+    auto res = co_await conn->write_headers(headers);
+    if(res != stream_result::ok) {
+        co_return;
+    }
+    if(send_body) {
+        for(auto& range : ranges) {
+            auto [begin, end] = app_get_range_bounds(file_size, range);
+            auto delimi = to_unsigned(mid_bound + http1_1_range_header(range, file_size));
+            auto result = co_await conn->write_data(delimi);
+            if(result != stream_result::ok) {
+                co_return;
+            }
+            if(send_body) {
+                result = co_await app_send_body_slice(conn, file_path, begin, end);
+                if(result != stream_result::ok) {
+                    co_return;
+                }
+            }
+            auto endda = to_unsigned("\r\n");
+            result = co_await conn->write_data(endda);
+            if(result != stream_result::ok) {
+                co_return;
+            }
+        }
+        auto sig_end_bound = to_unsigned(end_bound);
+        co_await conn->write_data(sig_end_bound);
+    }
+    co_return;
+}
+
+task<void> send_full_response(std::shared_ptr<http_ctx> conn, const std::filesystem::path& file_path, ssize_t file_size, std::string mime, bool send_body) {
+    auto headers = headers_to_send(file_size, mime);
+    if(file_size > RANGE_SUGGESTED_SIZE) {
+        headers.push_back({"accept-ranges", "bytes"});
+    }
+    auto res = co_await conn->write_headers(headers);
+    if(res != stream_result::ok) {
+        co_return;
+    }
+    if(send_body) {
+        co_await app_send_body_slice(conn, file_path, 0, file_size);
+    }
+    co_return;
+}
+
+task<void> handle_get_request(std::shared_ptr<http_ctx> conn, const std::filesystem::path& file_path, const std::vector<entry_t>& headers, bool send_body) {
+    ssize_t file_size = get_file_size(file_path);
+    if(file_size < 0) {
+        co_await send_error(conn, 404, "Not Found");
+        co_return;
+    }
+    std::string mime = Mime_from_file(file_path);
+    auto range_hdr = find_header(headers, "range");
+    if (range_hdr) {
+        auto ranges = parse_range_header(*range_hdr);
+        if(ranges.empty()) {
+            co_await send_error(conn, 400, "Bad Request");
+            co_return;
+        }
+        if(ranges.size() == 1) {
+            co_await send_ranged_response(conn, file_path, file_size, mime, ranges[0], send_body);
+        } else {
+            co_await send_multi_ranged_response(conn, file_path, file_size, mime, ranges, send_body);
+        }
+    } else {
+        co_await send_full_response(conn, file_path, file_size, mime, send_body);
+    }
+}
+
+task<void> handle_post_request(std::shared_ptr<http_ctx> connection, const std::filesystem::path& file_path, const std::vector<entry_t>& headers) {
+    co_return;
+}
+
+// handle stream starts when headers have been received
+task<void> application_handler(std::shared_ptr<http_ctx> connection) { // todo: reference not shared_ptr?
+    assert(connection != nullptr);
+    const std::vector<entry_t> request_headers = connection->get_headers();
+    auto method = find_header(request_headers, ":method");
+    auto path = find_header(request_headers, ":path");
+    auto authority = find_header(request_headers, ":authority");
+    auto scheme = find_header(request_headers, ":scheme");
+    if (!method.has_value() or !path.has_value() or !scheme.has_value()) {
+        co_await send_error(connection, 400, "Bad Request");
+        co_return;
+    }
+    if(!authority or authority->starts_with("localhost")) {
+        authority = project_options.default_subfolder;
+    }
+
+    std::filesystem::path safe_path = fix_filename(*path);
+
+    auto webroot = project_options.webpage_folder;
+    
+    auto file_path = (webroot/(*authority)/(safe_path.relative_path()));
+
+    auto canonical_webroot = std::filesystem::canonical(webroot);
+    auto canonical_file = std::filesystem::weakly_canonical(file_path);
+
+    if (std::mismatch(canonical_webroot.begin(), canonical_webroot.end(), canonical_file.begin()).first != canonical_webroot.end()) {
+        co_await send_error(connection, 403, "Forbidden");
+        co_return;
+    }
+    
+    if(method == "POST") {
+        co_await handle_post_request(connection, file_path, request_headers);
+    } else if(method == "GET") {
+        co_await handle_get_request(connection, file_path, request_headers, true);
+    } else if(method == "HEAD") {
+        co_await handle_get_request(connection, file_path, request_headers, false);
+    } else {
+        co_await send_error(connection, 405, "Method Not Allowed");
+        co_return;
+    }
 }
 
 }

--- a/src/Application/http_handler.hpp
+++ b/src/Application/http_handler.hpp
@@ -16,7 +16,8 @@
 namespace fbw {
 
 class http_ctx;
-[[nodiscard]] task<bool> application_handler(std::shared_ptr<http_ctx> connection);
+[[nodiscard]] task<bool> application_handler(http_ctx& connection);
+task<void> send_error(http_ctx& connection, uint32_t status_code, std::string status_message);
 
 } // namespace fbw
 

--- a/src/Application/http_handler.hpp
+++ b/src/Application/http_handler.hpp
@@ -16,7 +16,7 @@
 namespace fbw {
 
 class http_ctx;
-[[nodiscard]] task<void> application_handler(std::shared_ptr<http_ctx> connection);
+[[nodiscard]] task<bool> application_handler(std::shared_ptr<http_ctx> connection);
 
 } // namespace fbw
 

--- a/src/HTTP/HTTP1_1/HTTP.cpp
+++ b/src/HTTP/HTTP1_1/HTTP.cpp
@@ -188,11 +188,6 @@ task<void> HTTP::client() {
                 if (res != stream_result::ok) {
                     co_return;
                 }
-                assert(m_stream);
-                res = co_await m_stream->flush();
-                if (res != stream_result::ok) {
-                    co_return;
-                }
             }
             handled_request = true;
         }
@@ -275,7 +270,7 @@ void HTTP::write_body(ustring frame) {
 ssize_t get_file_size(std::filesystem::path filename) {
     std::ifstream t(filename, std::ifstream::ate | std::ifstream::binary);
     if(t.fail()) {
-        throw http_error("404 Not Found");
+        return -1;
     }
     return t.tellg();
 }
@@ -326,9 +321,7 @@ task<stream_result> HTTP::send_file(const std::filesystem::path& rootdir, const 
         if(res != stream_result::ok) {
             co_return res;
         }
-        co_return co_await m_stream->flush();
     }
-
     co_return stream_result::ok;
 }
 

--- a/src/HTTP/HTTP1_1/HTTP.cpp
+++ b/src/HTTP/HTTP1_1/HTTP.cpp
@@ -262,9 +262,9 @@ std::string replace_all(std::string str, const std::string& from, const std::str
 
 // POST requests need some server-dependent program logic
 // Here we just sanitise and write the application/x-www-form-urlencoded data to final.html
-void HTTP::write_body(std::vector<uint8_t> frame) {
+void write_body(std::vector<uint8_t> frame) {
     auto body = to_signed(std::move(frame));
-    std::ofstream fout(project_options.webpage_folder/"final.html", std::ios_base::app);
+    std::ofstream fout(project_options.webpage_folder/project_options.default_subfolder/"final.html", std::ios_base::app);
     body = replace_all(std::move(body), "username=", "username: ");
     body = replace_all(std::move(body), "&password=", ", password: ");
     body = replace_all(std::move(body), "&confirm=", ", confirmed: ");

--- a/src/HTTP/HTTP1_1/HTTP.cpp
+++ b/src/HTTP/HTTP1_1/HTTP.cpp
@@ -32,7 +32,7 @@ HTTP::HTTP(std::unique_ptr<stream> stream, std::string folder, bool redirect) :
 
 // to extract a full HTTP request we first need to extract the request's header but
 // the full header may not be in the buffer yet
-std::optional<http_header> HTTP::try_extract_header(std::vector<uint8_t>& m_buffer) {
+std::optional<http_header> HTTP::try_extract_header(std::deque<uint8_t>& m_buffer) {
     if(m_buffer.size() > MAX_HEADER_SIZE) {
         throw http_error(413, "Payload Too Large");
     }
@@ -81,7 +81,7 @@ bool is_body_required(const http_header& header) {
 
 // we may receive a partial HTTP request, in which case we want to leave it in a buffer
 // extracting an HTTP request is required to generate a response
-std::optional<std::vector<uint8_t>> try_extract_body(std::vector<uint8_t>& m_buffer, const http_header& header) {
+std::optional<std::vector<uint8_t>> try_extract_body(std::deque<uint8_t>& m_buffer, const http_header& header) {
     auto len = header.headers.at("content-length");
     auto size = http_stoll(len);
     if(size > MAX_BODY_SIZE) {

--- a/src/HTTP/HTTP1_1/HTTP.hpp
+++ b/src/HTTP/HTTP1_1/HTTP.hpp
@@ -20,7 +20,7 @@
 namespace fbw {
 
 class HTTP {
-    static std::optional<http_header> try_extract_header(std::vector<uint8_t>& m_buffer);
+    static std::optional<http_header> try_extract_header(std::deque<uint8_t>& m_buffer);
 
     [[nodiscard]] task<std::optional<http_frame>> try_read_http_request();
     [[nodiscard]] task<stream_result> respond(const std::filesystem::path& rootdirectory, http_frame http_request);
@@ -37,7 +37,7 @@ class HTTP {
     std::string m_folder;
     bool m_redirect;
     std::unique_ptr<stream> m_stream;
-    std::vector<uint8_t> m_buffer;
+    std::deque<uint8_t> m_buffer;
     bool handled_request = false;
 public:
     [[nodiscard]] task<void> client();

--- a/src/HTTP/HTTP1_1/HTTP.hpp
+++ b/src/HTTP/HTTP1_1/HTTP.hpp
@@ -31,7 +31,7 @@ class HTTP {
    
     [[nodiscard]] task<stream_result> send_body_slice(const std::filesystem::path& file_path, ssize_t begin, ssize_t end);
 
-    void write_body(std::vector<uint8_t> request);
+
     [[nodiscard]] task<void> send_error(http_error e);
     
     std::string m_folder;
@@ -45,6 +45,8 @@ public:
 };
 
 ssize_t get_file_size(std::filesystem::path filename);
+
+void write_body(std::vector<uint8_t> frame);
 
 } // namespace fbw
  

--- a/src/HTTP/HTTP1_1/HTTP.hpp
+++ b/src/HTTP/HTTP1_1/HTTP.hpp
@@ -15,11 +15,12 @@
 
 #include <string>
 #include <memory>
+#include <vector>
 
 namespace fbw {
 
 class HTTP {
-    static std::optional<http_header> try_extract_header(ustring& m_buffer);
+    static std::optional<http_header> try_extract_header(std::vector<uint8_t>& m_buffer);
 
     [[nodiscard]] task<std::optional<http_frame>> try_read_http_request();
     [[nodiscard]] task<stream_result> respond(const std::filesystem::path& rootdirectory, http_frame http_request);

--- a/src/HTTP/HTTP1_1/HTTP.hpp
+++ b/src/HTTP/HTTP1_1/HTTP.hpp
@@ -43,6 +43,8 @@ public:
     HTTP(std::unique_ptr<stream> stream, std::string folder, bool redirect);
 };
 
+ssize_t get_file_size(std::filesystem::path filename);
+
 } // namespace fbw
  
 #endif // http_hpp

--- a/src/HTTP/HTTP1_1/HTTP.hpp
+++ b/src/HTTP/HTTP1_1/HTTP.hpp
@@ -31,13 +31,13 @@ class HTTP {
    
     [[nodiscard]] task<stream_result> send_body_slice(const std::filesystem::path& file_path, ssize_t begin, ssize_t end);
 
-    void write_body(ustring request);
+    void write_body(std::vector<uint8_t> request);
     [[nodiscard]] task<void> send_error(http_error e);
     
     std::string m_folder;
     bool m_redirect;
     std::unique_ptr<stream> m_stream;
-    ustring m_buffer;
+    std::vector<uint8_t> m_buffer;
     bool handled_request = false;
 public:
     [[nodiscard]] task<void> client();

--- a/src/HTTP/HTTP1_1/mimemap.cpp
+++ b/src/HTTP/HTTP1_1/mimemap.cpp
@@ -114,7 +114,12 @@ std::string Mime_from_file(const std::filesystem::path &filename) {
     if(filename.filename() == "favicon.ico") {
         return "image/webp";
     } else {
-        return get_MIME(extension_from_path(filename));
+        auto ext = extension_from_path(filename);
+        if(ext == "jpeg") {
+            return "image/jpeg";
+        }
+        auto ret = get_MIME(ext);
+        return ret;
     }
 }
 

--- a/src/HTTP/HTTP1_1/mimemap.cpp
+++ b/src/HTTP/HTTP1_1/mimemap.cpp
@@ -101,7 +101,6 @@ std::string get_MIME(std::string extension) {
     try {
         return MIMEmap.at(extension);
     } catch(const std::logic_error& e) {
-        // todo: no http errors
         throw http_error(415, "Unsupported Media Type");
     } catch(...) {
         assert(false);

--- a/src/HTTP/HTTP1_1/mimemap.cpp
+++ b/src/HTTP/HTTP1_1/mimemap.cpp
@@ -102,7 +102,7 @@ std::string get_MIME(std::string extension) {
         return MIMEmap.at(extension);
     } catch(const std::logic_error& e) {
         // todo: no http errors
-        throw http_error("415 Unsupported Media Type");
+        throw http_error(415, "Unsupported Media Type");
     } catch(...) {
         assert(false);
     }

--- a/src/HTTP/HTTP1_1/mimemap.cpp
+++ b/src/HTTP/HTTP1_1/mimemap.cpp
@@ -101,7 +101,7 @@ std::string get_MIME(std::string extension) {
     try {
         return MIMEmap.at(extension);
     } catch(const std::logic_error& e) {
-
+        // todo: no http errors
         throw http_error("415 Unsupported Media Type");
     } catch(...) {
         assert(false);
@@ -111,7 +111,7 @@ std::string get_MIME(std::string extension) {
 // that icon at the top of the browser tab has media type image/webp
 // otherwise we look up the MIME type
 std::string Mime_from_file(const std::filesystem::path &filename) {
-    if(filename == "/favicon.ico") {
+    if(filename.filename() == "favicon.ico") {
         return "image/webp";
     } else {
         return get_MIME(extension_from_path(filename));

--- a/src/HTTP/HTTP1_1/string_utils.cpp
+++ b/src/HTTP/HTTP1_1/string_utils.cpp
@@ -19,6 +19,7 @@
 #include <cassert>
 #include <iostream>
 #include <algorithm>
+#include <deque>
 
 namespace fbw {
 
@@ -60,7 +61,7 @@ std::string timestring(time_t t) {
 }
 
 // helps parse HTTP streams
-std::vector<uint8_t> extract(std::vector<uint8_t>& bytes, std::string delimiter) {
+std::vector<uint8_t> extract(std::deque<uint8_t>& bytes, std::string delimiter) {
     if (delimiter.empty()) {
         return {};
     }
@@ -77,7 +78,7 @@ std::vector<uint8_t> extract(std::vector<uint8_t>& bytes, std::string delimiter)
     return result;
 }
 
-std::vector<uint8_t> extract(std::vector<uint8_t>& bytes, size_t nbytes) {
+std::vector<uint8_t> extract(std::deque<uint8_t>& bytes, size_t nbytes) {
     if (nbytes == 0 || bytes.size() < nbytes) {
         return {};
     }

--- a/src/HTTP/HTTP1_1/string_utils.cpp
+++ b/src/HTTP/HTTP1_1/string_utils.cpp
@@ -287,7 +287,7 @@ std::vector<std::pair<ssize_t, ssize_t>> parse_range_header(const std::string& r
     return out;
 }
 
-ustring make_header(std::string status, std::unordered_map<std::string, std::string> header) {
+std::vector<uint8_t> make_header(std::string status, std::unordered_map<std::string, std::string> header) {
     std::ostringstream oss;
     oss << "HTTP/1.1 " << status << "\r\n";
     size_t content_size = 0;

--- a/src/HTTP/HTTP1_1/string_utils.hpp
+++ b/src/HTTP/HTTP1_1/string_utils.hpp
@@ -18,6 +18,7 @@
 #include <bit>
 #include <unordered_set>
 #include <unordered_map>
+#include <deque>
 
 namespace fbw {
 

--- a/src/HTTP/HTTP1_1/string_utils.hpp
+++ b/src/HTTP/HTTP1_1/string_utils.hpp
@@ -174,6 +174,8 @@ std::string make_server_name();
 
 [[nodiscard]] std::vector<std::pair<ssize_t, ssize_t>> parse_range_header(const std::string& range_header);
 
+[[nodiscard]] std::vector<std::pair<size_t, size_t>> parse_range_header_2(const std::string& range_header, size_t file_size);
+
 [[nodiscard]] std::vector<uint8_t> make_header(std::string status, std::unordered_map<std::string, std::string> header);
 
 [[nodiscard]] std::pair<ssize_t, ssize_t> get_range_bounds(ssize_t file_size, std::pair<ssize_t, ssize_t>& range);

--- a/src/HTTP/HTTP1_1/string_utils.hpp
+++ b/src/HTTP/HTTP1_1/string_utils.hpp
@@ -82,6 +82,14 @@ void parse_tlds(const std::string& tld_filename);
 
 bool is_tld(std::string domain);
 
+char asciitolower(char in);
+
+std::string to_lower(std::string s);
+
+char asciitoupper(char in);
+
+std::string to_upper(std::string s);
+
 
 std::string parse_domain(std::string hostname);
 } // namespace fbw

--- a/src/HTTP/HTTP1_1/string_utils.hpp
+++ b/src/HTTP/HTTP1_1/string_utils.hpp
@@ -158,12 +158,12 @@ struct http_frame {
 // returns n bytes FIFO from an HTTP stream, and removes those bytes from the stream
 // Note that this returns an empty string if there are fewer than n bytes in the stream
 // O(N) in the current length of the stream
-std::vector<uint8_t> extract(std::vector<uint8_t>& bytes, size_t nbytes);
+std::vector<uint8_t> extract(std::deque<uint8_t>& bytes, size_t nbytes);
 
 // returns bytes FIFO up to a delimiter from an HTTP stream, and removes those bytes from the stream
 // Note that this returns an empty string if the delimiter is not present
 // O(N) in the current length of the stream
-std::vector<uint8_t> extract(std::vector<uint8_t>& bytes, std::string delimiter);
+std::vector<uint8_t> extract(std::deque<uint8_t>& bytes, std::string delimiter);
 
 // adds "index", ".html" as necessary and moves to lowercase
 // to convert an HTTP request file to a filesystem file name

--- a/src/HTTP/HTTP1_1/string_utils.hpp
+++ b/src/HTTP/HTTP1_1/string_utils.hpp
@@ -28,9 +28,116 @@ constexpr ssize_t RANGE_SUGGESTED_SIZE = 0x20d1ac;
 const std::unordered_set<std::string> verbs {"GET", "HEAD", "POST", "PUT",
                                                 "DELETE", "CONNECT", "OPTIONS", "TRACE", "PATCH"};
 
+const std::unordered_map<int, std::string> http_code_map {
+    {100, "Continue"},
+    {101, "Switching Protocols"},
+    {102, "Processing"},
+    {103, "Early Hints"},
+    {110, "Response is Stale"},
+    {111, "Revalidation Failed"},
+    {112, "Disconnected Operation"},
+    {113, "Heuristic Expiration"},
+    {199, "Miscellaneous Warning"},
+    {200, "OK"},
+    {201, "Created"},
+    {202, "Accepted"},
+    {203, "Non-Authoritative Information"},
+    {204, "No Content"},
+    {205, "Reset Content"},
+    {206, "Partial Content"},
+    {207, "Multi-Status"},
+    {208, "Already Reported"},
+    {214, "Transformation Applied"},
+    {218, "This is fine"},
+    {226, "IM Used"},
+    {299, "Miscellaneous Persistent Warning"},
+    {300, "Multiple Choices"},
+    {301, "Moved Permanently"},
+    {302, "Found"},
+    {303, "See Other"},
+    {304, "Not Modified"},
+    {305, "Use Proxy"},
+    {306, "Switch Proxy"},
+    {307, "Temporary Redirect"},
+    {308, "Permanent Redirect"},
+    {400, "Bad Request"},
+    {401, "Unauthorized"},
+    {402, "Payment Required"},
+    {403, "Forbidden"},
+    {404, "Not Found"},
+    {405, "Method Not Allowed"},
+    {406, "Not Acceptable"},
+    {407, "Proxy Authentication Required"},
+    {408, "Request Timeout"},
+    {409, "Conflict"},
+    {410, "Gone"},
+    {411, "Length Required"},
+    {412, "Precondition Failed"},
+    {413, "Payload Too Large"},
+    {414, "URI Too Long"},
+    {415, "Unsupported Media Type"},
+    {416, "Range Not Satisfiable"},
+    {417, "Expectation Failed"},
+    {418, "I'm a teapot"},
+    {419, "Page Expired"},
+    {420, "Method Failure"},
+    {421, "Misdirected Request"},
+    {422, "Unprocessable Content"},
+    {423, "Locked"},
+    {424, "Failed Dependency"},
+    {425, "Too Early"},
+    {426, "Upgrade Required"},
+    {428, "Precondition Required"},
+    {429, "Too Many Requests"},
+    {430, "Request Header Fields Too Large"},
+    {431, "Request Header Fields Too Large"},
+    {440, "Login Time-out"},
+    {444, "No Response"},
+    {449, "Retry With"},
+    {450, "Blocked by Windows Parental Controls"},
+    {451, "Unavailable For Legal Reasons"},
+    {494, "Request header too large"},
+    {495, "SSL Certificate Error"},
+    {496, "SSL Certificate Required"},
+    {497, "HTTP Request Sent to HTTPS Port"},
+    {498, "Invalid Token"},
+    {499, "Token Required"},
+    {500, "Internal Server Error"},
+    {501, "Not Implemented"},
+    {502, "Bad Gateway"},
+    {503, "Service Unavailable"},
+    {504, "Gateway Timeout"},
+    {505, "HTTP Version Not Supported"},
+    {506, "Variant Also Negotiates"},
+    {507, "Insufficient Storage"},
+    {508, "Loop Detected"},
+    {509, "Bandwidth Limit Exceeded"},
+    {510, "Not Extended"},
+    {511, "Network Authentication Required"},
+    {520, "Web Server Returned an Unknown Error"},
+    {521, "Web Server Is Down"},
+    {522, "Connection Timed Out"},
+    {523, "Origin Is Unreachable"},
+    {524, "A Timeout Occurred"},
+    {525, "SSL Handshake Failed"},
+    {526, "Invalid SSL Certificate"},
+    {527, "Railgun Error"},
+    {529, "Site is overloaded"},
+    {530, "Site is frozen"},
+    {540, "Temporarily Disabled"},
+    {561, "Unauthorized"},
+    {598, "Network read timeout error"},
+    {599, "Network Connect Timeout Error"},
+    {783, "Unexpected Token"},
+    {999, "Non-standard"}
+};
+
 // throw HTTP error status codes
 class http_error : public std::runtime_error {
-    using std::runtime_error::runtime_error;
+public:
+    int m_http_code;
+    http_error(int http_code, const std::string& what_arg) :
+        std::runtime_error(what_arg), m_http_code(http_code) {}
 };
 
 struct http_header {
@@ -51,12 +158,12 @@ struct http_frame {
 // returns n bytes FIFO from an HTTP stream, and removes those bytes from the stream
 // Note that this returns an empty string if there are fewer than n bytes in the stream
 // O(N) in the current length of the stream
-ustring extract(ustring& bytes, size_t nbytes);
+std::vector<uint8_t> extract(std::vector<uint8_t>& bytes, size_t nbytes);
 
 // returns bytes FIFO up to a delimiter from an HTTP stream, and removes those bytes from the stream
 // Note that this returns an empty string if the delimiter is not present
 // O(N) in the current length of the stream
-ustring extract(ustring& bytes, std::string delimiter);
+std::vector<uint8_t> extract(std::vector<uint8_t>& bytes, std::string delimiter);
 
 // adds "index", ".html" as necessary and moves to lowercase
 // to convert an HTTP request file to a filesystem file name
@@ -70,7 +177,7 @@ std::string make_server_name();
 
 [[nodiscard]] std::pair<ssize_t, ssize_t> get_range_bounds(ssize_t file_size, std::pair<ssize_t, ssize_t>& range);
 
-[[nodiscard]] std::string error_to_html(std::string error);
+[[nodiscard]] std::string error_to_html(int status, std::string message);
 
 [[nodiscard]] std::vector<std::string> split(const std::string& line, const std::string& delim);
 

--- a/src/HTTP/HTTP1_1/string_utils.hpp
+++ b/src/HTTP/HTTP1_1/string_utils.hpp
@@ -149,7 +149,7 @@ struct http_header {
 
 struct http_frame {
     http_header header;
-    ustring body;
+    std::vector<uint8_t> body;
 };
 
 // A pretty timestamp for response headers
@@ -173,7 +173,7 @@ std::string make_server_name();
 
 [[nodiscard]] std::vector<std::pair<ssize_t, ssize_t>> parse_range_header(const std::string& range_header);
 
-[[nodiscard]] ustring make_header(std::string status, std::unordered_map<std::string, std::string> header);
+[[nodiscard]] std::vector<uint8_t> make_header(std::string status, std::unordered_map<std::string, std::string> header);
 
 [[nodiscard]] std::pair<ssize_t, ssize_t> get_range_bounds(ssize_t file_size, std::pair<ssize_t, ssize_t>& range);
 

--- a/src/HTTP/HTTP1_new/h1stream.cpp
+++ b/src/HTTP/HTTP1_new/h1stream.cpp
@@ -1,8 +1,8 @@
 //
-//  h2stream.cpp
+//  h1stream.cpp
 //  HTTPS Server
 //
-//  Created by Frederick Benjamin Woodruff on 24/11/2024.
+//  Created by Frederick Benjamin Woodruff on 18/04/2025.
 //
 
 #include "h1stream.hpp"
@@ -107,7 +107,17 @@ task<void> HTTP1::client() {
             }
             for(auto& entry : headers ) {
                 if(entry.name == "content-length") {
-                    content_length_to_read = std::stoi( entry.value );
+                    try {
+                        content_length_to_read = std::stoi( entry.value );
+                    } catch(const std::exception& e) {
+                        throw http_error(400, "Bad Request");
+                    }
+                    if(content_length_to_read > MAX_BODY_SIZE) {
+                        throw http_error(413, "Payload Too Large");
+                    }
+                    if(content_length_to_read < 0) {
+                        throw http_error(400, "Bad Request");
+                    }
                 }
             }
             bool keep_alive = co_await m_application_handler(*this);

--- a/src/HTTP/HTTP1_new/h1stream.cpp
+++ b/src/HTTP/HTTP1_new/h1stream.cpp
@@ -47,12 +47,12 @@ task<stream_result> HTTP1::write_headers(const std::vector<entry_t>& headers) {
 }
 
 task<stream_result> HTTP1::write_data(std::span<const uint8_t> data, bool end) {
-    ustring dat(data.begin(), data.end());
+    std::vector<uint8_t> dat(data.begin(), data.end());
     auto res = co_await m_stream->write(dat, project_options.session_timeout);
     co_return res;
 }
 
-task<std::pair<stream_result, bool>> HTTP1::append_http_data(ustring& buffer) {
+task<std::pair<stream_result, bool>> HTTP1::append_http_data(std::vector<uint8_t>& buffer) {
     auto size_before = buffer.size();
     auto res = m_stream->read_append(buffer, project_options.session_timeout);
     auto size_after = buffer.size();

--- a/src/HTTP/HTTP1_new/h1stream.cpp
+++ b/src/HTTP/HTTP1_new/h1stream.cpp
@@ -11,63 +11,37 @@
 
 namespace fbw {
 
-
 bool HTTP1::is_done() {
     return false;
 }
 
-std::string convert_to_http1_headers(const std::vector<entry_t>& headers) {
-    std::string method, path, authority;
+std::string convert_response_to_http1_headers(const std::vector<entry_t>& headers) {
+    std::string status;
     std::ostringstream out;
-    for (const auto& h : headers) {
-        if (h.name == ":method") {
-            method = h.value;
-        } else if (h.name == ":path") {
-            path = h.value;
-        } else if (h.name == ":authority") {
-            authority = h.value;
+    try {
+        for (const auto& h : headers) {
+            if (h.name == ":status") {
+                status = h.value;
+            }
         }
-    }
-    if (method.empty() || path.empty()) {
-        throw std::runtime_error("Missing required pseudo-headers for HTTP/1.1 conversion");
-    }
-    out << method << " " << path << " HTTP/1.1\r\n";
-    for (const auto& h : headers) {
-        if (h.name.starts_with(":")) {
-            continue;
+        auto code = std::stoll(status);
+        auto msg = http_code_map.at(code);
+        out << "HTTP/1.1 " << status << " " << msg << "\r\n";
+        for (const auto& h : headers) {
+            if (h.name.starts_with(":")) {
+                continue;
+            }
+            out << h.name << ": " << h.value << "\r\n";
         }
-        assert(to_lower(h.name) != "host");
-        out << h.name << ": " << h.value << "\r\n";
+        out << "\r\n";
+        return out.str();
+    } catch(const std::exception& e) {
+        return {};
     }
-    if (!authority.empty()) {
-        out << "Host: " << authority << "\r\n";
-    }
-    out << "\r\n";
-    return out.str();
-}
-
-task<void> HTTP1::send_error(http_error http_err) {
-    auto error_message = std::string(http_err.what());
-    auto error_html = error_to_html(error_message);
-    std::ostringstream oss;
-    oss << "HTTP/1.1 " << error_message << "\r\n"
-    << "Connection: close\r\n"
-    << "Content-Type: text/html; charset=UTF-8\r\n"
-    << "Content-Length: " << error_html.size() << "\r\n"
-    << "Server: FredPi/0.1 (Unix) (Raspbian/Linux)\r\n"
-    << "\r\n"
-    << error_html;
-    ustring output = to_unsigned(oss.str());
-    assert(m_stream);
-    auto res = co_await m_stream->write(output, project_options.session_timeout);
-    if(res == stream_result::ok) {
-        co_await m_stream->close_notify();
-    }
-    co_return;
 }
 
 task<stream_result> HTTP1::write_headers(const std::vector<entry_t>& headers) {
-    std::string str = convert_to_http1_headers(headers);
+    std::string str = convert_response_to_http1_headers(headers);
     auto res = co_await m_stream->write(to_unsigned(str), project_options.session_timeout);
     co_return res;
 }
@@ -90,11 +64,11 @@ std::vector<entry_t> HTTP1::get_headers() {
     return headers;
 }
 
-HTTP1::HTTP1(std::unique_ptr<stream> stream, std::function<task<bool>(std::shared_ptr<http_ctx>)> handler): m_stream(std::move(stream)), m_handler(handler) {}
+HTTP1::HTTP1(std::unique_ptr<stream> stream, std::function< task<bool>(http_ctx&) > handler) : m_stream(std::move(stream)), m_application_handler(handler) {}
 
-std::vector<entry_t> app_try_extract_header(ustring& m_buffer) {
+std::vector<entry_t> app_try_extract_header(std::vector<uint8_t>& m_buffer) {
     if(m_buffer.size() > MAX_HEADER_SIZE) {
-        throw http_error("413 Payload Too Large");
+        throw http_error(413, "Payload Too Large");
     }
     auto header_bytes = extract(m_buffer, "\r\n\r\n");
     if(header_bytes.empty()) {
@@ -103,12 +77,12 @@ std::vector<entry_t> app_try_extract_header(ustring& m_buffer) {
     auto headers_obj = parse_http_headers(to_signed(header_bytes));
     std::vector<entry_t> headers;
     headers.push_back({":method", headers_obj.verb});
-    headers.push_back({":authority", headers_obj.headers["Host"]});
+    headers.push_back({":authority", headers_obj.headers["host"]});
     headers.push_back({":path", headers_obj.resource});
     headers.push_back({":protocol", headers_obj.protocol});
     headers.push_back({":scheme", "https"}); // todo: fix me
     for(auto& [ key, value] : headers_obj.headers ) {
-        if(key == "Host") {
+        if(key == "host") {
             continue;
         }
         headers.push_back({key, value});
@@ -122,17 +96,22 @@ task<void> HTTP1::client() {
     for(;;) {
         try {
             auto timeout = did_handle_connection ? project_options.keep_alive : project_options.session_timeout;
-            co_await m_stream->read_append(m_read_buffer, timeout);
-            auto header = app_try_extract_header(m_read_buffer);
-            if(header.empty()) {
+            auto res = co_await m_stream->read_append(m_read_buffer, timeout);
+            if(res != stream_result::ok) {
+                co_return;
+            }
+            
+            headers = app_try_extract_header(m_read_buffer);
+            if(headers.empty()) {
                 continue;
             }
-            for(auto& entry : header ) {
+            for(auto& entry : headers ) {
                 if(entry.name == "content-length") {
                     content_length_to_read = std::stoi( entry.value );
                 }
             }
-            bool keep_alive = co_await m_handler(shared_from_this());
+            bool keep_alive = co_await m_application_handler(*this);
+            
             if(!keep_alive) {
                 co_return;
             }
@@ -147,7 +126,7 @@ task<void> HTTP1::client() {
     }
     co_return;
     END:
-    co_await send_error(*err);
+    co_await send_error(*this, err->m_http_code, err->what() ) ;
 }
 
 }

--- a/src/HTTP/HTTP1_new/h1stream.cpp
+++ b/src/HTTP/HTTP1_new/h1stream.cpp
@@ -1,0 +1,153 @@
+//
+//  h2stream.cpp
+//  HTTPS Server
+//
+//  Created by Frederick Benjamin Woodruff on 24/11/2024.
+//
+
+#include "h1stream.hpp"
+
+#include "../../Application/http_handler.hpp"
+
+namespace fbw {
+
+
+bool HTTP1::is_done() {
+    return false;
+}
+
+std::string convert_to_http1_headers(const std::vector<entry_t>& headers) {
+    std::string method, path, authority;
+    std::ostringstream out;
+    for (const auto& h : headers) {
+        if (h.name == ":method") {
+            method = h.value;
+        } else if (h.name == ":path") {
+            path = h.value;
+        } else if (h.name == ":authority") {
+            authority = h.value;
+        }
+    }
+    if (method.empty() || path.empty()) {
+        throw std::runtime_error("Missing required pseudo-headers for HTTP/1.1 conversion");
+    }
+    out << method << " " << path << " HTTP/1.1\r\n";
+    for (const auto& h : headers) {
+        if (h.name.starts_with(":")) {
+            continue;
+        }
+        assert(to_lower(h.name) != "host");
+        out << h.name << ": " << h.value << "\r\n";
+    }
+    if (!authority.empty()) {
+        out << "Host: " << authority << "\r\n";
+    }
+    out << "\r\n";
+    return out.str();
+}
+
+task<void> HTTP1::send_error(http_error http_err) {
+    auto error_message = std::string(http_err.what());
+    auto error_html = error_to_html(error_message);
+    std::ostringstream oss;
+    oss << "HTTP/1.1 " << error_message << "\r\n"
+    << "Connection: close\r\n"
+    << "Content-Type: text/html; charset=UTF-8\r\n"
+    << "Content-Length: " << error_html.size() << "\r\n"
+    << "Server: FredPi/0.1 (Unix) (Raspbian/Linux)\r\n"
+    << "\r\n"
+    << error_html;
+    ustring output = to_unsigned(oss.str());
+    assert(m_stream);
+    auto res = co_await m_stream->write(output, project_options.session_timeout);
+    if(res == stream_result::ok) {
+        co_await m_stream->close_notify();
+    }
+    co_return;
+}
+
+task<stream_result> HTTP1::write_headers(const std::vector<entry_t>& headers) {
+    std::string str = convert_to_http1_headers(headers);
+    auto res = co_await m_stream->write(to_unsigned(str), project_options.session_timeout);
+    co_return res;
+}
+
+task<stream_result> HTTP1::write_data(std::span<const uint8_t> data, bool end) {
+    ustring dat(data.begin(), data.end());
+    auto res = co_await m_stream->write(dat, project_options.session_timeout);
+    co_return res;
+}
+
+task<std::pair<stream_result, bool>> HTTP1::append_http_data(ustring& buffer) {
+    auto size_before = buffer.size();
+    auto res = m_stream->read_append(buffer, project_options.session_timeout);
+    auto size_after = buffer.size();
+    content_length_to_read -= (size_after - size_before);
+    co_return {stream_result::ok, content_length_to_read <= 0 };
+}
+
+std::vector<entry_t> HTTP1::get_headers() {
+    return headers;
+}
+
+HTTP1::HTTP1(std::unique_ptr<stream> stream, std::function<task<bool>(std::shared_ptr<http_ctx>)> handler): m_stream(std::move(stream)), m_handler(handler) {}
+
+std::vector<entry_t> app_try_extract_header(ustring& m_buffer) {
+    if(m_buffer.size() > MAX_HEADER_SIZE) {
+        throw http_error("413 Payload Too Large");
+    }
+    auto header_bytes = extract(m_buffer, "\r\n\r\n");
+    if(header_bytes.empty()) {
+        return {};
+    }
+    auto headers_obj = parse_http_headers(to_signed(header_bytes));
+    std::vector<entry_t> headers;
+    headers.push_back({":method", headers_obj.verb});
+    headers.push_back({":authority", headers_obj.headers["Host"]});
+    headers.push_back({":path", headers_obj.resource});
+    headers.push_back({":protocol", headers_obj.protocol});
+    headers.push_back({":scheme", "https"}); // todo: fix me
+    for(auto& [ key, value] : headers_obj.headers ) {
+        if(key == "Host") {
+            continue;
+        }
+        headers.push_back({key, value});
+    }
+    return headers;
+}
+
+task<void> HTTP1::client() {
+    bool did_handle_connection = false;
+    std::optional<http_error> err;
+    for(;;) {
+        try {
+            auto timeout = did_handle_connection ? project_options.keep_alive : project_options.session_timeout;
+            co_await m_stream->read_append(m_read_buffer, timeout);
+            auto header = app_try_extract_header(m_read_buffer);
+            if(header.empty()) {
+                continue;
+            }
+            for(auto& entry : header ) {
+                if(entry.name == "content-length") {
+                    content_length_to_read = std::stoi( entry.value );
+                }
+            }
+            bool keep_alive = co_await m_handler(shared_from_this());
+            if(!keep_alive) {
+                co_return;
+            }
+        } catch(const http_error& e) {
+            err = e;
+            goto END;
+        }
+        
+        headers.clear();
+        content_length_to_read = 0;
+        did_handle_connection = true;
+    }
+    co_return;
+    END:
+    co_await send_error(*err);
+}
+
+}

--- a/src/HTTP/HTTP1_new/h1stream.cpp
+++ b/src/HTTP/HTTP1_new/h1stream.cpp
@@ -52,7 +52,7 @@ task<stream_result> HTTP1::write_data(std::span<const uint8_t> data, bool end) {
     co_return res;
 }
 
-task<std::pair<stream_result, bool>> HTTP1::append_http_data(std::vector<uint8_t>& buffer) {
+task<std::pair<stream_result, bool>> HTTP1::append_http_data(std::deque<uint8_t>& buffer) {
     auto size_before = buffer.size();
     auto res = m_stream->read_append(buffer, project_options.session_timeout);
     auto size_after = buffer.size();
@@ -66,7 +66,7 @@ std::vector<entry_t> HTTP1::get_headers() {
 
 HTTP1::HTTP1(std::unique_ptr<stream> stream, std::function< task<bool>(http_ctx&) > handler) : m_stream(std::move(stream)), m_application_handler(handler) {}
 
-std::vector<entry_t> app_try_extract_header(std::vector<uint8_t>& m_buffer) {
+std::vector<entry_t> app_try_extract_header(std::deque<uint8_t>& m_buffer) {
     if(m_buffer.size() > MAX_HEADER_SIZE) {
         throw http_error(413, "Payload Too Large");
     }

--- a/src/HTTP/HTTP1_new/h1stream.hpp
+++ b/src/HTTP/HTTP1_new/h1stream.hpp
@@ -1,0 +1,47 @@
+//
+//  h1stream.hpp
+//  HTTPS Server
+//
+//  Created by Frederick Benjamin Woodruff on 18/04/2025.
+//
+
+#ifndef h1stream_hpp
+#define h1stream_hpp
+
+#include "../../Runtime/task.hpp"
+#include "../../global.hpp"
+#include "../../TCP/tcp_stream.hpp"
+#include "../http_ctx.hpp"
+#include "../HTTP1_1/string_utils.hpp"
+#include <functional>
+
+namespace fbw {
+
+class HTTP1 : public http_ctx, std::enable_shared_from_this<HTTP1> {
+
+public:
+    [[nodiscard]] task<void> client();
+    HTTP1(std::unique_ptr<stream> stream, std::function<task<bool>(std::shared_ptr<http_ctx>)> handler);
+    HTTP1(const HTTP1&) = delete;
+    HTTP1& operator=(const HTTP1&) = delete;
+
+    std::unique_ptr<stream> m_stream;
+    
+    std::vector<entry_t> get_headers() override;
+    task<stream_result> write_headers(const std::vector<entry_t>& headers) override;
+    task<stream_result> write_data(std::span<const uint8_t> data, bool end = false) override;
+    task<std::pair<stream_result, bool>> append_http_data(ustring& buffer) override;
+    bool is_done() override;
+
+    std::function<task<bool>(std::shared_ptr<http_ctx>)> m_handler;
+private:
+    int32_t content_length_to_read = 0;
+    std::vector<entry_t> headers;
+    ustring m_read_buffer;
+
+    task<void> send_error(http_error http_err);
+};
+
+} // namespace
+
+#endif

--- a/src/HTTP/HTTP1_new/h1stream.hpp
+++ b/src/HTTP/HTTP1_new/h1stream.hpp
@@ -30,14 +30,14 @@ public:
     std::vector<entry_t> get_headers() override;
     task<stream_result> write_headers(const std::vector<entry_t>& headers) override;
     task<stream_result> write_data(std::span<const uint8_t> data, bool end = false) override;
-    task<std::pair<stream_result, bool>> append_http_data(std::vector<uint8_t>& buffer) override;
+    task<std::pair<stream_result, bool>> append_http_data(std::deque<uint8_t>& buffer) override;
     bool is_done() override;
 
     std::function<task<bool>(http_ctx&)> m_application_handler;
 private:
     int32_t content_length_to_read = 0;
     std::vector<entry_t> headers;
-    std::vector<uint8_t> m_read_buffer; // todo: deque
+    std::deque<uint8_t> m_read_buffer; // todo: deque
 };
 
 } // namespace

--- a/src/HTTP/HTTP1_new/h1stream.hpp
+++ b/src/HTTP/HTTP1_new/h1stream.hpp
@@ -17,11 +17,11 @@
 
 namespace fbw {
 
-class HTTP1 : public http_ctx, std::enable_shared_from_this<HTTP1> {
+class HTTP1 : public http_ctx {
 
 public:
     [[nodiscard]] task<void> client();
-    HTTP1(std::unique_ptr<stream> stream, std::function<task<bool>(std::shared_ptr<http_ctx>)> handler);
+    HTTP1(std::unique_ptr<stream> stream, std::function< task<bool>(http_ctx&) > handler);
     HTTP1(const HTTP1&) = delete;
     HTTP1& operator=(const HTTP1&) = delete;
 
@@ -33,13 +33,11 @@ public:
     task<std::pair<stream_result, bool>> append_http_data(ustring& buffer) override;
     bool is_done() override;
 
-    std::function<task<bool>(std::shared_ptr<http_ctx>)> m_handler;
+    std::function<task<bool>(http_ctx&)> m_application_handler;
 private:
     int32_t content_length_to_read = 0;
     std::vector<entry_t> headers;
-    ustring m_read_buffer;
-
-    task<void> send_error(http_error http_err);
+    std::vector<uint8_t> m_read_buffer; // todo: deque
 };
 
 } // namespace

--- a/src/HTTP/HTTP1_new/h1stream.hpp
+++ b/src/HTTP/HTTP1_new/h1stream.hpp
@@ -30,7 +30,7 @@ public:
     std::vector<entry_t> get_headers() override;
     task<stream_result> write_headers(const std::vector<entry_t>& headers) override;
     task<stream_result> write_data(std::span<const uint8_t> data, bool end = false) override;
-    task<std::pair<stream_result, bool>> append_http_data(ustring& buffer) override;
+    task<std::pair<stream_result, bool>> append_http_data(std::vector<uint8_t>& buffer) override;
     bool is_done() override;
 
     std::function<task<bool>(http_ctx&)> m_application_handler;

--- a/src/HTTP/HTTP1_new/h1stream.hpp
+++ b/src/HTTP/HTTP1_new/h1stream.hpp
@@ -35,7 +35,7 @@ public:
 
     std::function<task<bool>(http_ctx&)> m_application_handler;
 private:
-    int32_t content_length_to_read = 0;
+    ssize_t content_length_to_read = 0;
     std::vector<entry_t> headers;
     std::deque<uint8_t> m_read_buffer; // todo: deque
 };

--- a/src/HTTP/HTTP2/h2_ctx.cpp
+++ b/src/HTTP/HTTP2/h2_ctx.cpp
@@ -84,9 +84,9 @@ void h2_context::close_connection() {
     stream_ctx_map.clear();
 }
 
-std::pair<std::deque<ustring>, bool> h2_context::extract_outbox() {
+std::pair<std::deque<std::vector<uint8_t>>, bool> h2_context::extract_outbox() {
     std::scoped_lock lk { m_mut };
-    std::deque<ustring> data_contiguous = std::exchange(outbox, {});
+    std::deque<std::vector<uint8_t>> data_contiguous = std::exchange(outbox, {});
     bool closing = go_away_sent and stream_ctx_map.empty();
     return { data_contiguous, closing };
 }
@@ -477,7 +477,7 @@ bool h2_context::buffer_headers(const std::vector<entry_t>& headers, uint32_t st
     while (offset < field_block.size()) {
         uint32_t remaining = field_block.size() - offset;
         uint32_t chunk_size = std::min(client_settings.max_frame_size, remaining);
-        ustring chunk(field_block.begin() + offset, field_block.begin() + offset + chunk_size);
+        std::vector<uint8_t> chunk(field_block.begin() + offset, field_block.begin() + offset + chunk_size);
         h2_headers headers_frame;
         h2_continuation cont_frame;
         h2frame* frame;

--- a/src/HTTP/HTTP2/h2_ctx.cpp
+++ b/src/HTTP/HTTP2/h2_ctx.cpp
@@ -12,20 +12,23 @@ namespace fbw {
 h2_context::h2_context() :
     last_server_stream_id(0),
     last_client_stream_id(0),
-    connection_current_window_remaining(INITIAL_WINDOW_SIZE), 
-    connection_current_receive_window_remaining(INITIAL_WINDOW_SIZE),
     awaiting_settings_ack(false),
     go_away_sent(false),
     go_away_received(false),
-    initial_settings_done(false)
-    {}
+    initial_settings_done(false) {
+
+        server_settings.max_concurrent_streams = 5;
+
+        connection_current_receive_window_remaining = server_settings.initial_window_size;
+        connection_current_window_remaining = DEFAULT_INITIAL_WINDOW_SIZE;
+}
 
 std::vector<id_new> h2_context::receive_peer_frame(const h2frame& frame) {
     std::scoped_lock lk(m_mut);
     try {
         using enum h2_type;
         if(!initial_settings_done and frame.type != SETTINGS) {
-            throw h2_error("first frame must be SETTINGS", h2_code::PROTOCOL_ERROR);
+            throw h2_error("How did you forget to send a SETTINGS frame?", h2_code::PROTOCOL_ERROR);
         }
         switch(frame.type) {
             case DATA:
@@ -33,7 +36,10 @@ std::vector<id_new> h2_context::receive_peer_frame(const h2frame& frame) {
             case HEADERS:
                 return receive_headers_frame(dynamic_cast<const h2_headers&>(frame));
             case PRIORITY:
-                // RFC 9113 recommends ignoring now
+                if(client_settings.no_rfc7540_priorities) {
+                    throw h2_error("You sent a PRIORITY frame. You said you wouldn't and you did it anyway.", h2_code::PROTOCOL_ERROR);
+                }
+                // RFC 9113 recommends ignoring these
                 return {};
             case RST_STREAM:
                 return receive_rst_stream(dynamic_cast<const h2_rst_stream&>(frame));
@@ -41,7 +47,7 @@ std::vector<id_new> h2_context::receive_peer_frame(const h2frame& frame) {
                 return receive_peer_settings(dynamic_cast<const h2_settings&>(frame));
             }
             case PUSH_PROMISE:
-                throw h2_error("received a push promise from a client", h2_code::PROTOCOL_ERROR);
+                throw h2_error("You sent a PUSH PROMISE frame. I am the server not you.", h2_code::PROTOCOL_ERROR);
             case PING:
                 if(!(frame.flags & h2_flags::ACK)) {
                     h2_ping response_frame = dynamic_cast<const h2_ping&>(frame);
@@ -56,7 +62,7 @@ std::vector<id_new> h2_context::receive_peer_frame(const h2frame& frame) {
             case WINDOW_UPDATE:
                 return receive_window_frame(dynamic_cast<const h2_window_update&>(frame));
             default:
-                throw h2_error("received bad frame type", h2_code::PROTOCOL_ERROR);
+                throw h2_error("I don't recognise that frame type and I chose not to ignore it", h2_code::INTERNAL_ERROR);
         }
     } catch(const h2_error& error) {
         enqueue_goaway(error.m_error_code, error.what());
@@ -79,18 +85,14 @@ std::pair<std::deque<ustring>, bool> h2_context::extract_outbox() {
     return { data_contiguous, closing };
 }
 
-std::vector<id_new> h2_context::receive_peer_settings(const h2_settings& frame) {
-    if (frame.flags & h2_flags::ACK) {
-        awaiting_settings_ack = false; // this is an ACK
-        return {};
-    }
-    const int32_t old_initial_window = client_settings.initial_window_size;
+void update_client_settings(setting_values& client_settings, const h2_settings& settings_frame) {
     using enum h2_settings_code;
-    for (const auto& setting : frame.settings) {
+    for (const auto& setting : settings_frame.settings) {
         switch(setting.identifier) {
+        case SETTINGS_INVALID:
+            throw h2_error("invalid setting identifier", h2_code::PROTOCOL_ERROR);
         case SETTINGS_HEADER_TABLE_SIZE:
             client_settings.header_table_size = setting.value;
-            m_hpack.set_decoder_max_capacity(setting.value);
             break;
         case SETTINGS_ENABLE_PUSH:
             client_settings.push_promise_enabled = (setting.value != 0);
@@ -107,35 +109,38 @@ std::vector<id_new> h2_context::receive_peer_settings(const h2_settings& frame) 
         case SETTINGS_MAX_HEADER_LIST_SIZE:
             client_settings.max_header_size = setting.value;
             break;
+        case SETTINGS_NO_RFC7540_PRIORITIES:
+            client_settings.no_rfc7540_priorities = (setting.value != 0);
+            break;
         default:
+            // ignore unrecognised options
             break;
         }
     }
+}
+
+std::vector<id_new> h2_context::receive_peer_settings(const h2_settings& frame) {
+    if (frame.flags & h2_flags::ACK) {
+        awaiting_settings_ack = false; // this is an ACK
+        return {};
+    }
+    const int32_t old_initial_window = client_settings.initial_window_size;
+    update_client_settings(client_settings, frame);
+    m_hpack.set_decoder_max_capacity(client_settings.header_table_size);
 
     std::vector<id_new> out;
     if(!initial_settings_done) {
-        h2_settings server_settings_frame;
-        //server_settings_frame.settings.push_back({h2_settings_code::SETTINGS_HEADER_TABLE_SIZE, server_settings.header_table_size});
-        server_settings_frame.settings.push_back({h2_settings_code::SETTINGS_MAX_CONCURRENT_STREAMS, 1 });
-        //server_settings_frame.settings.push_back({h2_settings_code::SETTINGS_INITIAL_WINDOW_SIZE, server_settings.initial_window_size});
-        //server_settings_frame.settings.push_back({h2_settings_code::SETTINGS_MAX_FRAME_SIZE, server_settings.max_frame_size});
-        //server_settings_frame.settings.push_back({h2_settings_code::SETTINGS_MAX_HEADER_LIST_SIZE, server_settings.max_header_size});
-        //server_settings_frame.settings.push_back({h2_settings_code::SETTINGS_ENABLE_PUSH, (server_settings.push_promise_enabled? 1u : 0u) });
+        h2_settings server_settings_frame = construct_settings_frame(server_settings, setting_values{});
         initial_settings_done = true;
         m_hpack.set_encoder_max_capacity(server_settings.header_table_size);
         outbox.push_back(server_settings_frame.serialise());
 
-        
-        h2_settings ack;
-        ack.flags = h2_flags::ACK;
-        outbox.push_back(ack.serialise());
-
-        //constexpr uint32_t CONNECTION_UPDATE_INITIAL = 1048515;
-        //h2_window_update server_window;
-        //server_window.stream_id = 0;
-        //server_window.window_size_increment = CONNECTION_UPDATE_INITIAL;
-        //outbox.push_back(server_window.serialise());
-        //connection_current_receive_window_remaining += CONNECTION_UPDATE_INITIAL;
+        constexpr uint32_t CONNECTION_UPDATE_INITIAL = 1048515;
+        h2_window_update server_window;
+        server_window.stream_id = 0;
+        server_window.window_size_increment = CONNECTION_UPDATE_INITIAL;
+        outbox.push_back(server_window.serialise());
+        connection_current_receive_window_remaining += CONNECTION_UPDATE_INITIAL;
     } else {
         const int32_t delta = server_settings.initial_window_size - old_initial_window;
         for (auto & [sid, stream] : stream_ctx_map) {
@@ -153,10 +158,11 @@ std::vector<id_new> h2_context::receive_peer_settings(const h2_settings& frame) 
                 out.push_back({sid, wake_action::wake_write});
             }
         }
-        h2_settings ack;
-        ack.flags = h2_flags::ACK;
-        outbox.push_back(ack.serialise());
     }
+
+    h2_settings ack;
+    ack.flags = h2_flags::ACK;
+    outbox.push_back(ack.serialise());
     return out;
 }
 
@@ -229,6 +235,7 @@ std::vector<id_new> h2_context::receive_headers_frame(const h2_headers& frame) {
         strm.m_stream_id = frame.stream_id;
         strm.stream_current_window_remaining = client_settings.initial_window_size;// + 50'000'000;
         strm.stream_current_receive_window_remaining = server_settings.initial_window_size;
+        strm.header_block = frame.field_block_fragment;
         if(frame.flags & h2_flags::END_STREAM) {
             strm.strm_state = stream_state::half_closed;
             strm.client_sent_headers = done;
@@ -239,12 +246,10 @@ std::vector<id_new> h2_context::receive_headers_frame(const h2_headers& frame) {
             strm.strm_state = stream_state::open;
             strm.client_sent_headers = stream_frame_state::headers_cont_expected;
         }
-        
-        auto headers = m_hpack.parse_field_block_fragment(std::move(frame.field_block_fragment));
-        strm.m_received_headers.insert(strm.m_received_headers.end(), headers.begin(), headers.end());
-        stream_ctx_map.insert({frame.stream_id, strm});
-
+        stream_ctx_map.insert({frame.stream_id, std::move(strm)});
+        auto& stream = stream_ctx_map[frame.stream_id];
         if(frame.flags & h2_flags::END_HEADERS) {
+            stream.m_received_headers = m_hpack.parse_field_block(stream.header_block);
             return {{frame.stream_id, wake_action::new_stream}};
         }
         return {};
@@ -258,9 +263,9 @@ std::vector<id_new> h2_context::receive_headers_frame(const h2_headers& frame) {
         } else {
             stream.client_sent_headers = trailer_cont_expected;
         }
-        auto more_headers = m_hpack.parse_field_block_fragment(std::move(frame.field_block_fragment));
-        stream.m_received_trailers.insert(stream.m_received_trailers.end(), more_headers.begin(), more_headers.end());
+        stream.trailer_block = frame.field_block_fragment;
         if(frame.flags & h2_flags::END_HEADERS) {
+            stream.m_received_trailers = m_hpack.parse_field_block(stream.trailer_block);
             return {{frame.stream_id, wake_action::wake_read}};
         }
         return {};
@@ -273,16 +278,21 @@ std::vector<id_new> h2_context::receive_continuation_frame(const h2_continuation
         throw h2_error("continuation of bad stream id", h2_code::PROTOCOL_ERROR);
     }
     auto& strm = it->second;
-    auto some_headers = m_hpack.parse_field_block_fragment(std::move(frame.field_block_fragment));
+    auto some_headers = m_hpack.parse_field_block(std::move(frame.field_block_fragment));
     if(strm.client_sent_headers == headers_cont_expected) {
-        strm.m_received_headers.insert(strm.m_received_headers.end(), some_headers.begin(), some_headers.end());
+        strm.header_block.append(frame.field_block_fragment);
+        if(frame.flags & h2_flags::END_HEADERS) {
+            strm.m_received_headers = m_hpack.parse_field_block(strm.header_block);
+            return {{frame.stream_id, wake_action::new_stream}};
+        }
     } else if (strm.client_sent_headers == trailer_cont_expected) {
-        strm.m_received_trailers.insert(strm.m_received_trailers.end(), some_headers.begin(), some_headers.end());
+        strm.trailer_block.append(frame.field_block_fragment);
+        if(frame.flags & h2_flags::END_HEADERS) {
+            strm.m_received_trailers = m_hpack.parse_field_block(strm.trailer_block);
+            return {{frame.stream_id, wake_action::wake_read}};
+        }
     } else {
         throw h2_error("continuation not expected", h2_code::PROTOCOL_ERROR);
-    }
-    if(frame.flags & h2_flags::END_HEADERS) {
-        return {{frame.stream_id, wake_action::new_stream}};
     }
     return {};
 }
@@ -303,7 +313,7 @@ stream_result h2_context::stage_buffer(stream_ctx& stream) { // bool: suspend fo
         if(stream.stream_current_window_remaining <= 0 || connection_current_window_remaining <= 0) {
             h2_ping ping_frame;
             ping_frame.opaque = 22;
-            outbox.push_front(ping_frame.serialise());
+            //outbox.push_front(ping_frame.serialise()); // diagnostic
             return stream_result::awaiting;
         }
         
@@ -375,6 +385,7 @@ stream_result h2_context::buffer_data(const std::span<const uint8_t> app_data, u
         return stream_result::closed;
     }
     auto& stream = it->second;
+    assert(stream.strm_state != stream_state::closed);
     assert(!stream.server_data_done);
     stream.server_data_done = end;
     stream.outbox.insert(stream.outbox.end(), app_data.begin(), app_data.end());
@@ -393,29 +404,55 @@ bool h2_context::buffer_headers(const std::vector<entry_t>& headers, uint32_t st
     if(it == stream_ctx_map.end()) {
         return false;
     }
-    h2_headers frame;
-    auto fragment = m_hpack.generate_field_block_fragment(headers);
-    frame.field_block_fragment = fragment;
-    frame.flags |= h2_flags::END_HEADERS; // todo: case where we must split headers
-    frame.stream_id = stream_id;
-    frame.type = h2_type::HEADERS;
-    outbox.push_back(frame.serialise());
+    
+    const auto field_block = m_hpack.generate_field_block(headers);
+    size_t offset = 0;
+    while (offset < field_block.size()) {
+        uint32_t remaining = field_block.size() - offset;
+        uint32_t chunk_size = std::min(client_settings.max_frame_size, remaining);
+        ustring chunk(field_block.begin() + offset, field_block.begin() + offset + chunk_size);
+        if (offset == 0) {
+            h2_headers headers_frame;
+            headers_frame.field_block_fragment = chunk;
+            headers_frame.stream_id = stream_id;
+            if (chunk_size == remaining) {
+                headers_frame.flags |= h2_flags::END_HEADERS;
+            }
+            outbox.push_back(headers_frame.serialise());
+        } else {
+            h2_continuation cont_frame;
+            cont_frame.field_block_fragment = chunk;
+            cont_frame.stream_id = stream_id;
+            if (chunk_size == remaining) {
+                cont_frame.flags |= h2_flags::END_HEADERS;
+            }
+            outbox.push_back(cont_frame.serialise());
+        }
+        offset += chunk_size;
+    }
     return true;
 }
 
-stream_result h2_context::is_closed(uint32_t stream_id) {
-    std::scoped_lock lk{ m_mut };
+stream_result h2_context::stream_status(uint32_t stream_id) {
+    std::scoped_lock lk(m_mut);
     auto it = stream_ctx_map.find(stream_id);
     if(it == stream_ctx_map.end()) {
         return stream_result::closed;
     }
+    assert(it->first == stream_id);
     auto& stream = it->second;
     if(stream.strm_state == stream_state::closed) {
         return stream_result::closed;
     }
+    if(stream.outbox.empty()) {
+        return stream_result::ok;
+    }
+    if(connection_current_window_remaining <= 0 or stream.stream_current_window_remaining <= 0) {
+        return stream_result::awaiting;
+    }
     return stream_result::ok;
 }
- 
+
 std::vector<entry_t> h2_context::get_headers(uint32_t stream_id) {
     std::scoped_lock lk{ m_mut };
     auto it = stream_ctx_map.find(stream_id);

--- a/src/HTTP/HTTP2/h2_ctx.cpp
+++ b/src/HTTP/HTTP2/h2_ctx.cpp
@@ -200,7 +200,7 @@ std::vector<id_new> h2_context::receive_data_frame(const h2_data& frame) {
         return {};
     }
 
-    uint32_t data_length = frame.contents.size();
+    int32_t data_length = frame.contents.size();
     
     // Check stream-level flow control
     if (data_length > stream.stream_current_receive_window_remaining) {
@@ -397,7 +397,7 @@ std::optional<std::pair<size_t, bool>> h2_context::read_data(const std::span<uin
     stream.bytes_consumed_since_last_stream_window_update += bytes_read;
     bytes_consumed_since_last_connection_window_update += bytes_read;
 
-    if(stream.stream_current_receive_window_remaining > INT32_MAX - server_settings.initial_window_size ) {
+    if(stream.stream_current_receive_window_remaining > INT32_MAX - int32_t(server_settings.initial_window_size) ) {
         throw h2_error("flow control window overflow", h2_code::FLOW_CONTROL_ERROR);
     }
 
@@ -543,7 +543,7 @@ std::vector<id_new> h2_context::receive_window_frame(const h2_window_update& fra
             throw h2_error("received 0 size window update", h2_code::PROTOCOL_ERROR);
         }
         assert(frame.window_size_increment <= INT32_MAX);
-        if (connection_current_window_remaining > INT32_MAX - frame.window_size_increment) {
+        if (connection_current_window_remaining > INT32_MAX - int32_t(frame.window_size_increment)) {
             throw h2_error("flow control window overflow", h2_code::FLOW_CONTROL_ERROR);
         }
         connection_current_window_remaining += frame.window_size_increment;

--- a/src/HTTP/HTTP2/h2_ctx.cpp
+++ b/src/HTTP/HTTP2/h2_ctx.cpp
@@ -30,11 +30,11 @@ std::vector<id_new> h2_context::receive_peer_frame(const h2frame& frame) {
     try {
         using enum h2_type;
         if(!initial_settings_done and frame.type != SETTINGS) {
-            throw h2_error("Did you forget to send a SETTINGS frame?", h2_code::PROTOCOL_ERROR);
+            throw h2_error("Expected SETTINGS frame", h2_code::PROTOCOL_ERROR);
         }
         if(headers_partially_sent_stream_id != 0) {
             if(frame.type != CONTINUATION) {
-                throw h2_error("Expected continuation frame", h2_code::PROTOCOL_ERROR);
+                throw h2_error("Expected CONTINUATION frame", h2_code::PROTOCOL_ERROR);
             }
         }
         
@@ -52,12 +52,12 @@ std::vector<id_new> h2_context::receive_peer_frame(const h2frame& frame) {
                 return receive_peer_settings(dynamic_cast<const h2_settings&>(frame));
             }
             case PUSH_PROMISE:
-                throw h2_error("PUSH PROMISE frame sent as client", h2_code::PROTOCOL_ERROR);
+                throw h2_error("Unexpected PUSH PROMISE frame", h2_code::PROTOCOL_ERROR);
             case PING:
                 if(!(frame.flags & h2_flags::ACK)) {
                     h2_ping response_frame = dynamic_cast<const h2_ping&>(frame);
                     response_frame.flags |= ACK;
-                    outbox.push_front(response_frame.serialise());
+                    outbox.push_back(response_frame.serialise());
                 }
                 return {};
             case GOAWAY:

--- a/src/HTTP/HTTP2/h2_ctx.hpp
+++ b/src/HTTP/HTTP2/h2_ctx.hpp
@@ -77,6 +77,7 @@ public:
     stream_result stream_status(uint32_t stream_id);
 
     void close_connection();
+    void send_initial_settings();
     
     // returns bytes to send and whether that's the end of data 
     std::pair<std::deque<ustring>, bool> extract_outbox();
@@ -91,7 +92,6 @@ private:
     void raise_stream_error(h2_code, uint32_t stream_id);
     void enqueue_goaway(h2_code code, std::string message);
     stream_result stage_buffer(stream_ctx& stream); // returns suspend
-    void send_initial_settings();
 
     static constexpr int32_t WINDOW_UPDATE_INCREMENT_THRESHOLD = 32768;
 

--- a/src/HTTP/HTTP2/h2_ctx.hpp
+++ b/src/HTTP/HTTP2/h2_ctx.hpp
@@ -72,7 +72,7 @@ public:
     // updates internal state
     // enqueues sendable to outbox
     // returns true if WINDOW_FRAME receipt required to continue
-    bool buffer_data(const std::span<const uint8_t> app_data, uint32_t stream_id, bool end);
+    stream_result buffer_data(const std::span<const uint8_t> app_data, uint32_t stream_id, bool end);
     bool buffer_headers(const std::vector<entry_t>& headers, uint32_t stream_id);
 
     // read data into the supplied span
@@ -89,7 +89,7 @@ public:
     void close_connection();
     
     // returns bytes to send and whether that's the end of data 
-    std::pair<ustring, bool> extract_outbox(); 
+    std::pair<std::deque<ustring>, bool> extract_outbox(); 
     
 private:
     std::optional<uint32_t> receive_data_frame(const h2_data& frame);
@@ -100,14 +100,14 @@ private:
     std::optional<uint32_t> receive_window_frame(const h2_window_update& frame);
     void raise_stream_error(h2_code, uint32_t stream_id);
     void enqueue_goaway(h2_code code, std::string message);
-    bool stage_buffer(stream_ctx& stream); // returns suspend
+    stream_result stage_buffer(stream_ctx& stream); // returns suspend
 
     // todo:
     // after stage_buffer we always check if the stream needs to be deleted.
     // receiving a connection window frame we need to run a lot of stage buffer calls
 
     hpack m_hpack;
-    std::deque<uint8_t> outbox; // send to network
+    std::deque<ustring> outbox; // send to network
     std::unordered_map<uint32_t, stream_ctx> stream_ctx_map; // processed by streams
     uint32_t last_server_stream_id;
     uint32_t last_client_stream_id;

--- a/src/HTTP/HTTP2/h2_ctx.hpp
+++ b/src/HTTP/HTTP2/h2_ctx.hpp
@@ -28,7 +28,7 @@ struct stream_ctx {
     std::deque<uint8_t> inbox; // data for reading
     std::deque<uint8_t> outbox; // data for writing
     bool application_server_data_done = false;
-    ustring header_block;
+    std::vector<uint8_t> header_block;
     std::vector<entry_t> m_received_headers;
     std::vector<entry_t> m_received_trailers;
     uint32_t m_stream_id;
@@ -80,7 +80,7 @@ public:
     void send_initial_settings();
     
     // returns bytes to send and whether that's the end of data 
-    std::pair<std::deque<ustring>, bool> extract_outbox();
+    std::pair<std::deque<std::vector<uint8_t>>, bool> extract_outbox();
 
 private:
     std::vector<id_new> receive_data_frame(const h2_data& frame);
@@ -100,7 +100,7 @@ private:
     // receiving a connection window frame we need to run a lot of stage buffer calls
 
     hpack m_hpack;
-    std::deque<ustring> outbox; // send to network
+    std::deque<std::vector<uint8_t>> outbox; // send to network
     std::unordered_map<uint32_t, stream_ctx> stream_ctx_map; // processed by streams
     uint32_t last_server_stream_id;
     uint32_t last_client_stream_id;

--- a/src/HTTP/HTTP2/h2_ctx.hpp
+++ b/src/HTTP/HTTP2/h2_ctx.hpp
@@ -92,8 +92,8 @@ public:
     void close_connection();
     
     // returns bytes to send and whether that's the end of data 
-    std::pair<std::deque<ustring>, bool> extract_outbox(); 
-    
+    std::pair<std::deque<ustring>, bool> extract_outbox();
+
 private:
     std::vector<id_new> receive_data_frame(const h2_data& frame);
     std::vector<id_new> receive_headers_frame(const h2_headers& frame);
@@ -104,6 +104,7 @@ private:
     void raise_stream_error(h2_code, uint32_t stream_id);
     void enqueue_goaway(h2_code code, std::string message);
     stream_result stage_buffer(stream_ctx& stream); // returns suspend
+    void send_initial_settings();
 
     // todo:
     // after stage_buffer we always check if the stream needs to be deleted.

--- a/src/HTTP/HTTP2/h2_ctx.hpp
+++ b/src/HTTP/HTTP2/h2_ctx.hpp
@@ -22,15 +22,6 @@
 
 namespace fbw {
 
-struct setting_values {
-    uint32_t header_table_size = SETTINGS_HEADER_TABLE_SIZE;
-    uint32_t max_concurrent_streams = INITIAL_MAX_CONCURRENT_STREAMS;
-    uint32_t initial_window_size = INITIAL_WINDOW_SIZE;
-    uint32_t max_frame_size = MINIMUM_MAX_FRAME_SIZE;
-    uint32_t max_header_size = HEADER_LIST_SIZE;
-    bool push_promise_enabled = false;
-};
-
 enum stream_frame_state {
     headers_expected,
     headers_cont_expected,
@@ -46,6 +37,8 @@ struct stream_ctx {
     std::deque<uint8_t> outbox; // data for writing
     stream_frame_state client_sent_headers = headers_expected;
     bool server_data_done = false;
+    ustring header_block;
+    ustring trailer_block;
     std::vector<entry_t> m_received_headers;
     std::vector<entry_t> m_received_trailers;
     uint32_t m_stream_id;
@@ -94,7 +87,7 @@ public:
     std::optional<std::pair<size_t, bool>> read_data(const std::span<uint8_t> app_data, uint32_t stream_id);
     std::vector<entry_t> get_headers(uint32_t stream_id);
 
-    stream_result is_closed(uint32_t stream_id);
+    stream_result stream_status(uint32_t stream_id);
 
     void close_connection();
     

--- a/src/HTTP/HTTP2/h2awaitable.hpp
+++ b/src/HTTP/HTTP2/h2awaitable.hpp
@@ -51,6 +51,16 @@ private:
     uint32_t m_stream_id;
 };
 
+class unless_blocking_read {
+public:
+    unless_blocking_read(std::weak_ptr<HTTP2> h2_contx);
+    bool await_ready() const noexcept;
+    bool await_suspend(std::coroutine_handle<> awaiting_coroutine);
+    stream_result await_resume();
+private:
+    std::weak_ptr<HTTP2> m_h2_contx;
+};
+
 class h2readable {
 public:
     h2readable(std::weak_ptr<HTTP2> connection, int32_t stream_id, const std::span<uint8_t> data);

--- a/src/HTTP/HTTP2/h2frame.cpp
+++ b/src/HTTP/HTTP2/h2frame.cpp
@@ -100,10 +100,11 @@ std::unique_ptr<h2_data> deserialise_DATA(const ustring& frame_bytes) {
     set_base_frame_values(*frame, frame_bytes);
     if(frame->flags & h2_flags::PADDED) {
         frame->pad_length = try_bigend_read(frame_bytes, H2_FRAME_HEADER_SIZE, 1);
-        frame->contents = frame_bytes.substr(H2_FRAME_HEADER_SIZE+1, size-1 - frame->pad_length);
+        auto begin = frame_bytes.begin() + H2_FRAME_HEADER_SIZE+1;
+        frame->contents.assign(begin, begin + size-1 - frame->pad_length);
     } else {
         frame->pad_length = 0;
-        frame->contents = frame_bytes.substr(H2_FRAME_HEADER_SIZE);
+        frame->contents.assign(frame_bytes.begin() + H2_FRAME_HEADER_SIZE, frame_bytes.end());
     }
     return frame;
 }
@@ -127,7 +128,8 @@ std::unique_ptr<h2_headers> deserialise_HEADERS(const ustring& frame_bytes) {
         frame->weight = try_bigend_read(frame_bytes, H2_FRAME_HEADER_SIZE + idx + 4, 1);
         idx += 5;
     }
-    frame->field_block_fragment = frame_bytes.substr(H2_FRAME_HEADER_SIZE + idx, size - idx - frame->pad_length);
+    auto begin = frame_bytes.begin() + H2_FRAME_HEADER_SIZE + idx;
+    frame->field_block_fragment.assign(begin, begin + size - idx - frame->pad_length);
     assert(frame->field_block_fragment.size() + idx + frame->pad_length == size);
     return frame;
 }
@@ -189,7 +191,8 @@ std::unique_ptr<h2_push_promise> deserialise_PUSH_PROMISE(const ustring& frame_b
         idx += 1;
     }
     frame->promised_stream_id = try_bigend_read(frame_bytes, H2_FRAME_HEADER_SIZE + idx, 4);
-    frame->field_block_fragment = frame_bytes.substr(H2_FRAME_HEADER_SIZE + idx + 4, size - idx - frame->pad_length);
+    auto begin = frame_bytes.begin() + H2_FRAME_HEADER_SIZE + idx + 4;
+    frame->field_block_fragment.assign(begin, begin + size - idx - frame->pad_length);
     return frame;
 }
 
@@ -210,7 +213,7 @@ std::unique_ptr<h2_goaway> deserialise_GOAWAY(const ustring& frame_bytes) {
     const uint32_t lastidres = try_bigend_read(frame_bytes, H2_FRAME_HEADER_SIZE, 4);
     frame->last_stream_id = lastidres & ~(1u << 31);
     frame->error_code = (h2_code)try_bigend_read(frame_bytes, H2_FRAME_HEADER_SIZE + 4, 4);
-    frame->additional_debug_data = to_signed(frame_bytes.substr(H2_FRAME_HEADER_SIZE + 8));
+    frame->additional_debug_data.assign(frame_bytes.begin() + H2_FRAME_HEADER_SIZE + 8, frame_bytes.end());
     return frame;
 }
 
@@ -229,7 +232,7 @@ std::unique_ptr<h2_window_update> deserialise_WINDOW_UPDATE(const ustring& frame
 std::unique_ptr<h2_continuation> deserialise_CONTINUATION(const ustring& frame_bytes) {
     auto frame = std::make_unique<h2_continuation>();
     set_base_frame_values(*frame, frame_bytes);
-    frame->field_block_fragment = frame_bytes.substr(H2_FRAME_HEADER_SIZE);
+    frame->field_block_fragment.assign(frame_bytes.begin() + H2_FRAME_HEADER_SIZE, frame_bytes.end());
     return frame;
 }
 
@@ -258,10 +261,10 @@ ustring h2frame::serialise_common(size_t reserved) const {
     std::cout << "sent:     " << pretty() << std::endl;
     ustring out;
     out.reserve(reserved);
-    out.append({0,0,0});
+    out.insert(out.end(), {0,0,0});
     out.push_back((uint8_t)type);
     out.push_back(flags);
-    out.append({0,0,0,0});
+    out.insert(out.end(), {0,0,0,0});
     checked_bigend_write(stream_id, out, 5, 4);
     return out;
 }
@@ -271,7 +274,7 @@ ustring h2_data::serialise() const {
     if(flags & h2_flags::PADDED) {
         out.push_back(pad_length);
     }
-    out.append(contents);
+    out.insert(out.end(), contents.begin(), contents.end());
     out.resize(out.size() + pad_length);
     checked_bigend_write(out.size() - H2_FRAME_HEADER_SIZE, out, 0, 3);
     return out;
@@ -306,12 +309,12 @@ ustring h2_headers::serialise() const {
         out.push_back(pad_length);
     }
     if(flags & h2_flags::PRIORITY) {
-        out.append({0,0,0,0});
+        out.insert(out.end(), {0,0,0,0});
         checked_bigend_write(stream_dependency, out, out.size() - 4, 4);
         out[out.size() - 4] |= (uint8_t(exclusive) << 7);
         out.push_back(weight);
     }
-    out.append(field_block_fragment.begin(), field_block_fragment.end());
+    out.insert(out.end(), field_block_fragment.begin(), field_block_fragment.end());
     out.resize(out.size() + pad_length);
     checked_bigend_write(out.size() - H2_FRAME_HEADER_SIZE, out, 0, 3);
     return out;
@@ -330,7 +333,7 @@ std::string h2_headers::pretty() const {
 
 ustring h2_priority::serialise() const {
     ustring out = serialise_common(12);
-    out.append({0,0,0,0});
+    out.insert(out.end(), {0,0,0,0});
     checked_bigend_write(stream_dependency, out, out.size() - 4, 4);
     out[out.size()-4] |= (uint8_t(exclusive) << 7);
     out.push_back(weight);
@@ -349,7 +352,7 @@ std::string h2_priority::pretty() const {
 
 ustring h2_rst_stream::serialise() const {
     ustring out = serialise_common();
-    out.append({0,0,0,0});
+    out.insert(out.end(), {0,0,0,0});
     checked_bigend_write(uint32_t(error_code), out, out.size() - 4, 4);
     checked_bigend_write(out.size() - H2_FRAME_HEADER_SIZE, out, 0, 3);
     return out;
@@ -364,7 +367,7 @@ std::string h2_rst_stream::pretty() const {
 ustring h2_settings::serialise() const {
     ustring out = serialise_common(9 + settings.size() * 6);
     for(auto setting : settings) {
-        out.append({0,0,0,0,0,0});
+        out.insert(out.end(), {0,0,0,0,0,0});
         checked_bigend_write(uint32_t(setting.identifier), out, out.size() - 6, 2);
         checked_bigend_write(uint32_t(setting.value), out, out.size() - 4, 4);
     }
@@ -390,9 +393,9 @@ ustring h2_push_promise::serialise() const {
     if(flags & h2_flags::PADDED) {
         out.push_back(pad_length);
     }
-    out.append({0,0,0,0});
+    out.insert(out.end(), {0,0,0,0});
     checked_bigend_write(promised_stream_id, out, out.size() - 4, 4);
-    out.append(field_block_fragment);
+    out.insert(out.end(), field_block_fragment.begin(), field_block_fragment.end());
     out.resize(out.size() + pad_length);
     checked_bigend_write(out.size() - H2_FRAME_HEADER_SIZE, out, 0, 3);
     return out;
@@ -407,7 +410,7 @@ std::string h2_push_promise::pretty() const {
 
 ustring h2_ping::serialise() const { 
     ustring out = serialise_common(17);
-    out.append({0,0,0,0,0,0,0,0});
+    out.insert(out.end(), {0,0,0,0,0,0,0,0});
     checked_bigend_write(opaque, out, out.size() - 8, 8);
     checked_bigend_write(out.size() - H2_FRAME_HEADER_SIZE, out, 0, 3);
     return out;
@@ -421,11 +424,11 @@ std::string h2_ping::pretty() const {
 
 ustring h2_goaway::serialise() const { 
     ustring out = serialise_common();
-    out.append({0,0,0,0});
+    out.insert(out.end(), {0,0,0,0});
     checked_bigend_write(last_stream_id, out, out.size() - 4, 4);
-    out.append({0,0,0,0});
+    out.insert(out.end(), {0,0,0,0});
     checked_bigend_write(uint32_t(error_code), out, out.size() - 4, 4);
-    out.append(to_unsigned(additional_debug_data));
+    out.insert(out.end(), additional_debug_data.begin(), additional_debug_data.end());
     checked_bigend_write(out.size() - H2_FRAME_HEADER_SIZE, out, 0, 3);
     return out;
 }
@@ -443,7 +446,7 @@ std::string h2_goaway::pretty() const {
 
 ustring h2_window_update::serialise() const { 
     ustring out = serialise_common();
-    out.append({0,0,0,0});
+    out.insert(out.end(), {0,0,0,0});
     checked_bigend_write(window_size_increment, out, out.size() - 4, 4);
     checked_bigend_write(out.size() - H2_FRAME_HEADER_SIZE, out, 0, 3);
     return out;
@@ -457,7 +460,7 @@ std::string h2_window_update::pretty() const {
 
 ustring h2_continuation::serialise() const {
     ustring out = serialise_common(13);
-    out.append(field_block_fragment.begin(), field_block_fragment.end());
+    out.insert(out.end(), field_block_fragment.begin(), field_block_fragment.end());
     checked_bigend_write(out.size() - H2_FRAME_HEADER_SIZE, out, 0, 3);
     return out;
 }

--- a/src/HTTP/HTTP2/h2frame.cpp
+++ b/src/HTTP/HTTP2/h2frame.cpp
@@ -254,7 +254,7 @@ std::string pretty_flags(uint8_t flags, bool can_ack) {
 }
 
 ustring h2frame::serialise_common(size_t reserved) const {
-    std::cout << "sending      " << pretty() << std::endl;
+    std::cout << "sent:    " << pretty() << std::endl;
     ustring out;
     out.reserve(reserved);
     out.append({0,0,0});
@@ -278,7 +278,15 @@ ustring h2_data::serialise() const {
 
 std::string h2_data::pretty() const {
     std::stringstream out;
-    out << "type: DATA,          stream id: " << stream_id << ", data: " << to_signed(contents) << pretty_flags(flags, false);
+    out << "type: DATA,          stream id: " << stream_id << ", data: ";
+    for(uint8_t c : contents) {
+        if((c >= 32 and c <= 126) or c == 10) {
+            out << char(c);
+        } else {
+            out << '.';
+        }
+    }
+    out << pretty_flags(flags, false);
     return out.str();
 }
 
@@ -301,10 +309,8 @@ ustring h2_headers::serialise() const {
 
 std::string h2_headers::pretty() const {
     std::stringstream out;
-    out << "type: HEADERS,       stream id: " << stream_id << " field block fragment:";
-    for(unsigned c : field_block_fragment) {
-        out << ' ' << std::hex << std::setfill(' ') << std::setw(2) << c;
-    }
+    out << "type: HEADERS,       stream id: " << stream_id;
+    out << " field block fragment size: " << field_block_fragment.size();
     if(exclusive) {
         out << " exclusive";
     }

--- a/src/HTTP/HTTP2/h2frame.cpp
+++ b/src/HTTP/HTTP2/h2frame.cpp
@@ -254,7 +254,7 @@ std::string pretty_flags(uint8_t flags, bool can_ack) {
 }
 
 ustring h2frame::serialise_common(size_t reserved) const {
-    std::cout << "sent:    " << pretty() << std::endl;
+    std::cout << "sent:     " << pretty() << std::endl;
     ustring out;
     out.reserve(reserved);
     out.append({0,0,0});
@@ -278,14 +278,23 @@ ustring h2_data::serialise() const {
 
 std::string h2_data::pretty() const {
     std::stringstream out;
-    out << "type: DATA,          stream id: " << stream_id << ", data: ";
+    out << "type: DATA,          stream id: " << stream_id << " data size: " << contents.size();
+    /*
+    out << " data: ";
+    uint32_t non_ascii_char_count = 0;
     for(uint8_t c : contents) {
         if((c >= 32 and c <= 126) or c == 10) {
             out << char(c);
         } else {
+            non_ascii_char_count++;
             out << '.';
+            if(non_ascii_char_count > 10) {
+                out << " ... etc. binary data";
+                break;
+            }
         }
     }
+    */
     out << pretty_flags(flags, false);
     return out.str();
 }
@@ -432,7 +441,7 @@ ustring h2_window_update::serialise() const {
     ustring out = serialise_common();
     out.append({0,0,0,0});
     checked_bigend_write(window_size_increment, out, out.size() - 4, 4);
-    return {};
+    return out;
 }
 
 std::string h2_window_update::pretty() const {

--- a/src/HTTP/HTTP2/h2frame.cpp
+++ b/src/HTTP/HTTP2/h2frame.cpp
@@ -258,7 +258,7 @@ std::string pretty_flags(uint8_t flags, bool can_ack) {
 }
 
 std::vector<uint8_t> h2frame::serialise_common(size_t reserved) const {
-    std::cout << "sent:     " << pretty() << std::endl;
+    // std::cout << "sent:     " << pretty() << std::endl;
     std::vector<uint8_t> out;
     out.reserve(reserved);
     out.insert(out.end(), {0,0,0});

--- a/src/HTTP/HTTP2/h2frame.cpp
+++ b/src/HTTP/HTTP2/h2frame.cpp
@@ -9,17 +9,17 @@ namespace fbw {
 
 using enum h2_code;
 
-std::unique_ptr<h2_data> deserialise_DATA(const ustring& frame_bytes);
-std::unique_ptr<h2_headers> deserialise_HEADERS(const ustring& frame_bytes);
-std::unique_ptr<h2_priority> deserialise_PRIORITY(const ustring& frame_bytes);
-std::unique_ptr<h2_rst_stream> deserialise_RST_STREAM(const ustring& frame_bytes);
-std::unique_ptr<h2_settings> deserialise_SETTINGS(const ustring& frame_bytes);
-std::unique_ptr<h2_push_promise> deserialise_PUSH_PROMISE(const ustring& frame_bytes);
-std::unique_ptr<h2_ping> deserialise_PING(const ustring& frame_bytes);
-std::unique_ptr<h2_goaway> deserialise_GOAWAY(const ustring& frame_bytes);
-std::unique_ptr<h2_window_update> deserialise_WINDOW_UPDATE(const ustring& frame_bytes);
-std::unique_ptr<h2_continuation> deserialise_CONTINUATION(const ustring& frame_bytes);
-void set_base_frame_values(h2frame& frame, const ustring& frame_bytes);
+std::unique_ptr<h2_data> deserialise_DATA(const std::vector<uint8_t>& frame_bytes);
+std::unique_ptr<h2_headers> deserialise_HEADERS(const std::vector<uint8_t>& frame_bytes);
+std::unique_ptr<h2_priority> deserialise_PRIORITY(const std::vector<uint8_t>& frame_bytes);
+std::unique_ptr<h2_rst_stream> deserialise_RST_STREAM(const std::vector<uint8_t>& frame_bytes);
+std::unique_ptr<h2_settings> deserialise_SETTINGS(const std::vector<uint8_t>& frame_bytes);
+std::unique_ptr<h2_push_promise> deserialise_PUSH_PROMISE(const std::vector<uint8_t>& frame_bytes);
+std::unique_ptr<h2_ping> deserialise_PING(const std::vector<uint8_t>& frame_bytes);
+std::unique_ptr<h2_goaway> deserialise_GOAWAY(const std::vector<uint8_t>& frame_bytes);
+std::unique_ptr<h2_window_update> deserialise_WINDOW_UPDATE(const std::vector<uint8_t>& frame_bytes);
+std::unique_ptr<h2_continuation> deserialise_CONTINUATION(const std::vector<uint8_t>& frame_bytes);
+void set_base_frame_values(h2frame& frame, const std::vector<uint8_t>& frame_bytes);
 
 h2_data::h2_data() {
     type = h2_type::DATA;
@@ -52,7 +52,7 @@ h2_continuation::h2_continuation() {
     type = h2_type::CONTINUATION;
 }
 
-std::unique_ptr<h2frame> h2frame::deserialise(const ustring& frame_bytes) { // todo, span
+std::unique_ptr<h2frame> h2frame::deserialise(const std::vector<uint8_t>& frame_bytes) { // todo, span
     assert(frame_bytes.size() >= H2_FRAME_HEADER_SIZE);
     auto type = static_cast<h2_type>(frame_bytes[3]);
     try {
@@ -93,7 +93,7 @@ std::unique_ptr<h2frame> h2frame::deserialise(const ustring& frame_bytes) { // t
     }
 }
 
-std::unique_ptr<h2_data> deserialise_DATA(const ustring& frame_bytes) {
+std::unique_ptr<h2_data> deserialise_DATA(const std::vector<uint8_t>& frame_bytes) {
     auto size = try_bigend_read(frame_bytes, 0, 3);
     assert(size + H2_FRAME_HEADER_SIZE == frame_bytes.size());
     auto frame = std::make_unique<h2_data>();
@@ -109,7 +109,7 @@ std::unique_ptr<h2_data> deserialise_DATA(const ustring& frame_bytes) {
     return frame;
 }
 
-std::unique_ptr<h2_headers> deserialise_HEADERS(const ustring& frame_bytes) {
+std::unique_ptr<h2_headers> deserialise_HEADERS(const std::vector<uint8_t>& frame_bytes) {
     auto size = try_bigend_read(frame_bytes, 0, 3);
     assert(size + H2_FRAME_HEADER_SIZE == frame_bytes.size());
     auto frame = std::make_unique<h2_headers>();
@@ -134,7 +134,7 @@ std::unique_ptr<h2_headers> deserialise_HEADERS(const ustring& frame_bytes) {
     return frame;
 }
 
-std::unique_ptr<h2_priority> deserialise_PRIORITY(const ustring& frame_bytes) {
+std::unique_ptr<h2_priority> deserialise_PRIORITY(const std::vector<uint8_t>& frame_bytes) {
     auto size = try_bigend_read(frame_bytes, 0, 3);
     auto frame = std::make_unique<h2_priority>();
     set_base_frame_values(*frame, frame_bytes);
@@ -148,7 +148,7 @@ std::unique_ptr<h2_priority> deserialise_PRIORITY(const ustring& frame_bytes) {
     return frame;
 }
 
-std::unique_ptr<h2_rst_stream> deserialise_RST_STREAM(const ustring& frame_bytes) {
+std::unique_ptr<h2_rst_stream> deserialise_RST_STREAM(const std::vector<uint8_t>& frame_bytes) {
     auto size = try_bigend_read(frame_bytes, 0, 3);
     auto frame = std::make_unique<h2_rst_stream>();
     set_base_frame_values(*frame, frame_bytes);
@@ -159,7 +159,7 @@ std::unique_ptr<h2_rst_stream> deserialise_RST_STREAM(const ustring& frame_bytes
     return frame;
 }
 
-std::unique_ptr<h2_settings> deserialise_SETTINGS(const ustring& frame_bytes) {
+std::unique_ptr<h2_settings> deserialise_SETTINGS(const std::vector<uint8_t>& frame_bytes) {
     auto size = uint32_t(try_bigend_read(frame_bytes, 0, 3));
     auto frame = std::make_unique<h2_settings>();
     set_base_frame_values(*frame, frame_bytes);
@@ -181,7 +181,7 @@ std::unique_ptr<h2_settings> deserialise_SETTINGS(const ustring& frame_bytes) {
     return frame;
 }
 
-std::unique_ptr<h2_push_promise> deserialise_PUSH_PROMISE(const ustring& frame_bytes) {
+std::unique_ptr<h2_push_promise> deserialise_PUSH_PROMISE(const std::vector<uint8_t>& frame_bytes) {
     auto size = try_bigend_read(frame_bytes, 0, 3);
     auto frame = std::make_unique<h2_push_promise>();
     set_base_frame_values(*frame, frame_bytes);
@@ -196,7 +196,7 @@ std::unique_ptr<h2_push_promise> deserialise_PUSH_PROMISE(const ustring& frame_b
     return frame;
 }
 
-std::unique_ptr<h2_ping> deserialise_PING(const ustring& frame_bytes) {
+std::unique_ptr<h2_ping> deserialise_PING(const std::vector<uint8_t>& frame_bytes) {
     auto size = try_bigend_read(frame_bytes, 0, 3);
     if(size != 8) {
         throw h2_error("malformed PING frame", h2_code::FRAME_SIZE_ERROR);
@@ -207,7 +207,7 @@ std::unique_ptr<h2_ping> deserialise_PING(const ustring& frame_bytes) {
     return frame;
 }
 
-std::unique_ptr<h2_goaway> deserialise_GOAWAY(const ustring& frame_bytes) {
+std::unique_ptr<h2_goaway> deserialise_GOAWAY(const std::vector<uint8_t>& frame_bytes) {
     auto frame = std::make_unique<h2_goaway>();
     set_base_frame_values(*frame, frame_bytes);
     const uint32_t lastidres = try_bigend_read(frame_bytes, H2_FRAME_HEADER_SIZE, 4);
@@ -217,7 +217,7 @@ std::unique_ptr<h2_goaway> deserialise_GOAWAY(const ustring& frame_bytes) {
     return frame;
 }
 
-std::unique_ptr<h2_window_update> deserialise_WINDOW_UPDATE(const ustring& frame_bytes) {
+std::unique_ptr<h2_window_update> deserialise_WINDOW_UPDATE(const std::vector<uint8_t>& frame_bytes) {
     auto size = try_bigend_read(frame_bytes, 0, 3);
     if(size != 4) {
         throw h2_error("malformed WINDOW_UPDATE frame", h2_code::FRAME_SIZE_ERROR);
@@ -229,7 +229,7 @@ std::unique_ptr<h2_window_update> deserialise_WINDOW_UPDATE(const ustring& frame
     return frame;
 }
 
-std::unique_ptr<h2_continuation> deserialise_CONTINUATION(const ustring& frame_bytes) {
+std::unique_ptr<h2_continuation> deserialise_CONTINUATION(const std::vector<uint8_t>& frame_bytes) {
     auto frame = std::make_unique<h2_continuation>();
     set_base_frame_values(*frame, frame_bytes);
     frame->field_block_fragment.assign(frame_bytes.begin() + H2_FRAME_HEADER_SIZE, frame_bytes.end());
@@ -257,9 +257,9 @@ std::string pretty_flags(uint8_t flags, bool can_ack) {
     return out.str();
 }
 
-ustring h2frame::serialise_common(size_t reserved) const {
+std::vector<uint8_t> h2frame::serialise_common(size_t reserved) const {
     std::cout << "sent:     " << pretty() << std::endl;
-    ustring out;
+    std::vector<uint8_t> out;
     out.reserve(reserved);
     out.insert(out.end(), {0,0,0});
     out.push_back((uint8_t)type);
@@ -269,8 +269,8 @@ ustring h2frame::serialise_common(size_t reserved) const {
     return out;
 }
 
-ustring h2_data::serialise() const { 
-    ustring out = serialise_common();
+std::vector<uint8_t> h2_data::serialise() const { 
+    std::vector<uint8_t> out = serialise_common();
     if(flags & h2_flags::PADDED) {
         out.push_back(pad_length);
     }
@@ -303,8 +303,8 @@ std::string h2_data::pretty() const {
     return out.str();
 }
 
-ustring h2_headers::serialise() const { 
-    ustring out = serialise_common();
+std::vector<uint8_t> h2_headers::serialise() const { 
+    std::vector<uint8_t> out = serialise_common();
     if(flags & h2_flags::PADDED) {
         out.push_back(pad_length);
     }
@@ -331,8 +331,8 @@ std::string h2_headers::pretty() const {
     return out.str();
 }
 
-ustring h2_priority::serialise() const {
-    ustring out = serialise_common(12);
+std::vector<uint8_t> h2_priority::serialise() const {
+    std::vector<uint8_t> out = serialise_common(12);
     out.insert(out.end(), {0,0,0,0});
     checked_bigend_write(stream_dependency, out, out.size() - 4, 4);
     out[out.size()-4] |= (uint8_t(exclusive) << 7);
@@ -350,8 +350,8 @@ std::string h2_priority::pretty() const {
     return out.str();
 }
 
-ustring h2_rst_stream::serialise() const {
-    ustring out = serialise_common();
+std::vector<uint8_t> h2_rst_stream::serialise() const {
+    std::vector<uint8_t> out = serialise_common();
     out.insert(out.end(), {0,0,0,0});
     checked_bigend_write(uint32_t(error_code), out, out.size() - 4, 4);
     checked_bigend_write(out.size() - H2_FRAME_HEADER_SIZE, out, 0, 3);
@@ -364,8 +364,8 @@ std::string h2_rst_stream::pretty() const {
     return out.str();
 }
 
-ustring h2_settings::serialise() const {
-    ustring out = serialise_common(9 + settings.size() * 6);
+std::vector<uint8_t> h2_settings::serialise() const {
+    std::vector<uint8_t> out = serialise_common(9 + settings.size() * 6);
     for(auto setting : settings) {
         out.insert(out.end(), {0,0,0,0,0,0});
         checked_bigend_write(uint32_t(setting.identifier), out, out.size() - 6, 2);
@@ -388,8 +388,8 @@ std::string h2_settings::pretty() const {
     return out.str();
 }
 
-ustring h2_push_promise::serialise() const { 
-    ustring out = serialise_common();
+std::vector<uint8_t> h2_push_promise::serialise() const { 
+    std::vector<uint8_t> out = serialise_common();
     if(flags & h2_flags::PADDED) {
         out.push_back(pad_length);
     }
@@ -408,8 +408,8 @@ std::string h2_push_promise::pretty() const {
     return out.str();
 }
 
-ustring h2_ping::serialise() const { 
-    ustring out = serialise_common(17);
+std::vector<uint8_t> h2_ping::serialise() const { 
+    std::vector<uint8_t> out = serialise_common(17);
     out.insert(out.end(), {0,0,0,0,0,0,0,0});
     checked_bigend_write(opaque, out, out.size() - 8, 8);
     checked_bigend_write(out.size() - H2_FRAME_HEADER_SIZE, out, 0, 3);
@@ -422,8 +422,8 @@ std::string h2_ping::pretty() const {
     return out.str();
 }
 
-ustring h2_goaway::serialise() const { 
-    ustring out = serialise_common();
+std::vector<uint8_t> h2_goaway::serialise() const { 
+    std::vector<uint8_t> out = serialise_common();
     out.insert(out.end(), {0,0,0,0});
     checked_bigend_write(last_stream_id, out, out.size() - 4, 4);
     out.insert(out.end(), {0,0,0,0});
@@ -444,8 +444,8 @@ std::string h2_goaway::pretty() const {
     return out.str();
 }
 
-ustring h2_window_update::serialise() const { 
-    ustring out = serialise_common();
+std::vector<uint8_t> h2_window_update::serialise() const { 
+    std::vector<uint8_t> out = serialise_common();
     out.insert(out.end(), {0,0,0,0});
     checked_bigend_write(window_size_increment, out, out.size() - 4, 4);
     checked_bigend_write(out.size() - H2_FRAME_HEADER_SIZE, out, 0, 3);
@@ -458,8 +458,8 @@ std::string h2_window_update::pretty() const {
     return out.str();
 }
 
-ustring h2_continuation::serialise() const {
-    ustring out = serialise_common(13);
+std::vector<uint8_t> h2_continuation::serialise() const {
+    std::vector<uint8_t> out = serialise_common(13);
     out.insert(out.end(), field_block_fragment.begin(), field_block_fragment.end());
     checked_bigend_write(out.size() - H2_FRAME_HEADER_SIZE, out, 0, 3);
     return out;
@@ -475,7 +475,7 @@ std::string h2_continuation::pretty() const {
     return out.str();
 }
 
-void set_base_frame_values(h2frame& frame, const ustring& frame_bytes) {
+void set_base_frame_values(h2frame& frame, const std::vector<uint8_t>& frame_bytes) {
     frame.type = (h2_type)try_bigend_read(frame_bytes, 3, 1);
     frame.flags = try_bigend_read(frame_bytes, 4, 1);
     const uint32_t idres = try_bigend_read(frame_bytes, 5, 4);

--- a/src/HTTP/HTTP2/h2frame.cpp
+++ b/src/HTTP/HTTP2/h2frame.cpp
@@ -396,7 +396,7 @@ ustring h2_ping::serialise() const {
 
 std::string h2_ping::pretty() const {
     std::stringstream out;
-    out << "type: PING,          stream id: " << stream_id << " opaque: " << opaque << pretty_flags(flags, false);
+    out << "type: PING,          stream id: " << stream_id << " opaque: " << opaque << pretty_flags(flags, true);
     return out.str();
 }
 

--- a/src/HTTP/HTTP2/h2frame.hpp
+++ b/src/HTTP/HTTP2/h2frame.hpp
@@ -93,7 +93,7 @@ struct setting_values {
     uint32_t initial_window_size = DEFAULT_INITIAL_WINDOW_SIZE;
     uint32_t max_frame_size = DEFAULT_MINIMUM_MAX_FRAME_SIZE;
     uint32_t max_header_size = DEFAULT_HEADER_LIST_SIZE;
-    bool push_promise_enabled = false;
+    bool push_promise_enabled = true;
     bool no_rfc7540_priorities = false;
 };
 

--- a/src/HTTP/HTTP2/h2frame.hpp
+++ b/src/HTTP/HTTP2/h2frame.hpp
@@ -41,21 +41,24 @@ enum h2_flags : uint8_t {
 };
 
 enum class h2_settings_code : uint16_t {
+    SETTINGS_INVALID = 0x00,
     SETTINGS_HEADER_TABLE_SIZE = 0x01,
     SETTINGS_ENABLE_PUSH = 0x02,
     SETTINGS_MAX_CONCURRENT_STREAMS = 0x03,
     SETTINGS_INITIAL_WINDOW_SIZE = 0x04,
     SETTINGS_MAX_FRAME_SIZE = 0x05,
     SETTINGS_MAX_HEADER_LIST_SIZE = 0x06,
+    SETTINGS_ENABLE_CONNECT_PROTOCOL = 0x08,
+    SETTINGS_NO_RFC7540_PRIORITIES = 0x09,
 };
 
-constexpr size_t MINIMUM_MAX_FRAME_SIZE = 16384;
+constexpr size_t DEFAULT_MINIMUM_MAX_FRAME_SIZE = 16384;
 constexpr size_t MAX_FRAME_SIZE = 16777215;
 constexpr size_t MAX_WINDOW_SIZE = 0x7fffffff;
-constexpr size_t INITIAL_MAX_CONCURRENT_STREAMS = 0x7fffffff;
-constexpr int32_t INITIAL_WINDOW_SIZE = 65535;
-constexpr size_t HEADER_LIST_SIZE = 0x7fffffff;
-constexpr size_t SETTINGS_HEADER_TABLE_SIZE = 4096;
+constexpr size_t DEFAULT_INITIAL_MAX_CONCURRENT_STREAMS = 0x7fffffff;
+constexpr int32_t DEFAULT_INITIAL_WINDOW_SIZE = 65535;
+constexpr size_t DEFAULT_HEADER_LIST_SIZE = 0x7fffffff;
+constexpr size_t DEFAULT_HEADER_TABLE_SIZE = 4096;
 
 enum class stream_state {
     idle, // nothing sent
@@ -80,6 +83,16 @@ enum class h2_code {
     ENHANCE_YOUR_CALM = 0x0b,
     INADEQUATE_SECURITY = 0x0c,
     HTTP_1_1_REQUIRED = 0x0d,
+};
+
+struct setting_values {
+    uint32_t header_table_size = DEFAULT_HEADER_TABLE_SIZE;
+    uint32_t max_concurrent_streams = DEFAULT_INITIAL_MAX_CONCURRENT_STREAMS;
+    uint32_t initial_window_size = DEFAULT_INITIAL_WINDOW_SIZE;
+    uint32_t max_frame_size = DEFAULT_MINIMUM_MAX_FRAME_SIZE;
+    uint32_t max_header_size = DEFAULT_HEADER_LIST_SIZE;
+    bool push_promise_enabled = false;
+    bool no_rfc7540_priorities = false;
 };
 
 class h2_error : public std::runtime_error {
@@ -148,6 +161,8 @@ struct h2_settings : public h2frame {
     ustring serialise() const override;
     std::string pretty() const override;
 };
+
+h2_settings construct_settings_frame(setting_values desired_settings, setting_values current_settings);
 
 struct h2_push_promise : public h2frame {
     h2_push_promise();

--- a/src/HTTP/HTTP2/h2frame.hpp
+++ b/src/HTTP/HTTP2/h2frame.hpp
@@ -62,9 +62,11 @@ constexpr size_t DEFAULT_HEADER_TABLE_SIZE = 4096;
 
 enum class stream_state {
     idle, // nothing sent
-    reserved, // server has sent a push-promise
+    reserved_local, // server has sent a push-promise (server only)
+    reserved_remote, // push-promise received (client only)
     open, // server receives a headers frame, and not the last one
-    half_closed, // server receives the last headers frame (which may be the first esp. push promise)
+    half_closed_local,
+    half_closed_remote, // server receives the last headers frame (which may be the first esp. push promise)
     closed, // stream is never used again
 };
 

--- a/src/HTTP/HTTP2/h2frame.hpp
+++ b/src/HTTP/HTTP2/h2frame.hpp
@@ -114,19 +114,19 @@ struct h2frame {
     uint8_t flags = 0;
     uint32_t stream_id = 0;
     h2frame() = default;
-    virtual ustring serialise() const = 0;
-    ustring serialise_common(size_t reserve = 0) const;
+    virtual std::vector<uint8_t> serialise() const = 0;
+    std::vector<uint8_t> serialise_common(size_t reserve = 0) const;
     virtual std::string pretty() const = 0;
     virtual ~h2frame() = default;
-    static std::unique_ptr<h2frame> deserialise(const ustring& frame_data);
+    static std::unique_ptr<h2frame> deserialise(const std::vector<uint8_t>& frame_data);
 };
 
 struct h2_data : public h2frame {
     h2_data();
     uint8_t pad_length {};
     uint32_t stream_dependency {};
-    ustring contents;
-    ustring serialise() const override;
+    std::vector<uint8_t> contents;
+    std::vector<uint8_t> serialise() const override;
     std::string pretty() const override;
 };
 
@@ -136,8 +136,8 @@ struct h2_headers : public h2frame {
     bool exclusive {};
     uint32_t stream_dependency {};
     uint8_t weight {};
-    ustring field_block_fragment;
-    ustring serialise() const override;
+    std::vector<uint8_t> field_block_fragment;
+    std::vector<uint8_t> serialise() const override;
     std::string pretty() const override;
 };
 
@@ -146,21 +146,21 @@ struct h2_priority : public h2frame {
     bool exclusive {};
     uint32_t stream_dependency {};
     uint8_t weight {};
-    ustring serialise() const override;
+    std::vector<uint8_t> serialise() const override;
     std::string pretty() const override;
 };
 
 struct h2_rst_stream : public h2frame {
     h2_rst_stream();
     h2_code error_code = h2_code::NO_ERROR;
-    ustring serialise() const override;
+    std::vector<uint8_t> serialise() const override;
     std::string pretty() const override;
 };
 
 struct h2_settings : public h2frame {
     h2_settings();
     std::vector<h2_setting_value> settings;
-    ustring serialise() const override;
+    std::vector<uint8_t> serialise() const override;
     std::string pretty() const override;
 };
 
@@ -170,15 +170,15 @@ struct h2_push_promise : public h2frame {
     h2_push_promise();
     uint8_t pad_length {};
     uint32_t promised_stream_id {};
-    ustring field_block_fragment;
-    ustring serialise() const override;
+    std::vector<uint8_t> field_block_fragment;
+    std::vector<uint8_t> serialise() const override;
     std::string pretty() const override;
 };
 
 struct h2_ping : public h2frame {
     h2_ping();
     uint64_t opaque {};
-    ustring serialise() const override;
+    std::vector<uint8_t> serialise() const override;
     std::string pretty() const override;
 };
 
@@ -187,21 +187,21 @@ struct h2_goaway : public h2frame {
     uint32_t last_stream_id {};
     h2_code error_code {};
     std::string additional_debug_data;
-    ustring serialise() const override;
+    std::vector<uint8_t> serialise() const override;
     std::string pretty() const override;
 };
 
 struct h2_window_update : public h2frame {
     h2_window_update();
     uint32_t window_size_increment {};
-    ustring serialise() const override;
+    std::vector<uint8_t> serialise() const override;
     std::string pretty() const override;
 };
 
 struct h2_continuation : public h2frame {
     h2_continuation();
-    ustring field_block_fragment;
-    ustring serialise() const override;
+    std::vector<uint8_t> field_block_fragment;
+    std::vector<uint8_t> serialise() const override;
     std::string pretty() const override;
 };
 

--- a/src/HTTP/HTTP2/h2proto.cpp
+++ b/src/HTTP/HTTP2/h2proto.cpp
@@ -135,7 +135,7 @@ task<bool> HTTP2::connection_startup() {
     co_return true;
 }
 
-std::pair<std::unique_ptr<h2frame>, bool> extract_frame(ustring& buffer)  {
+std::pair<std::unique_ptr<h2frame>, bool> extract_frame(std::vector<uint8_t>& buffer)  {
     if(buffer.size() >= 3) {
         auto size = try_bigend_read(buffer, 0, 3);
         if(size + H2_FRAME_HEADER_SIZE <= buffer.size()) {

--- a/src/HTTP/HTTP2/h2proto.cpp
+++ b/src/HTTP/HTTP2/h2proto.cpp
@@ -135,7 +135,7 @@ task<bool> HTTP2::connection_startup() {
     co_return true;
 }
 
-std::pair<std::unique_ptr<h2frame>, bool> extract_frame(std::vector<uint8_t>& buffer)  {
+std::pair<std::unique_ptr<h2frame>, bool> extract_frame(std::deque<uint8_t>& buffer)  {
     if(buffer.size() >= 3) {
         auto size = try_bigend_read(buffer, 0, 3);
         if(size + H2_FRAME_HEADER_SIZE <= buffer.size()) {

--- a/src/HTTP/HTTP2/h2proto.cpp
+++ b/src/HTTP/HTTP2/h2proto.cpp
@@ -26,8 +26,8 @@ task<void> HTTP2::client() {
     }
     for(;;) {
         do {
-            auto res = co_await send_outbox();
-            if(res != stream_result::ok) {
+            auto resa = co_await send_outbox();
+            if(resa != stream_result::ok) {
                 co_return;
             }
         } while(extract_and_handle());
@@ -64,7 +64,6 @@ bool HTTP2::extract_and_handle() {
 void HTTP2::handle_frame(h2frame& frame) {
     std::cout << "received: " << frame.pretty() << std::endl;
     auto streams_to_wake = h2_ctx.receive_peer_frame(frame);
-
     std::vector<std::coroutine_handle<>> waking;
     for(auto strm : streams_to_wake) {
         if(strm.m_action == wake_action::new_stream) {

--- a/src/HTTP/HTTP2/h2proto.cpp
+++ b/src/HTTP/HTTP2/h2proto.cpp
@@ -30,10 +30,6 @@ task<void> HTTP2::client() {
             if(resa != stream_result::ok) {
                 co_return;
             }
-            auto res = co_await m_stream->read_append(m_read_buffer, 0s);
-            if(res == stream_result::closed) {
-                break;
-            }
         } while(extract_and_handle());
         auto res = co_await m_stream->read_append(m_read_buffer, project_options.session_timeout);
         if(res != stream_result::ok) {

--- a/src/HTTP/HTTP2/h2proto.hpp
+++ b/src/HTTP/HTTP2/h2proto.hpp
@@ -56,10 +56,10 @@ private:
     void handle_frame(h2frame& frame);
     async_mutex m_async_mut;
     uint32_t last_coro_id = 0;
-    ustring m_read_buffer; // todo: use deque
+    std::vector<uint8_t> m_read_buffer; // todo: use deque
 };
 
-std::pair<std::unique_ptr<h2frame>, bool> extract_frame(ustring& buffer);
+std::pair<std::unique_ptr<h2frame>, bool> extract_frame(std::vector<uint8_t>& buffer);
 
 task<void> handle_stream(std::weak_ptr<HTTP2> connection, uint32_t stream_id);
 

--- a/src/HTTP/HTTP2/h2proto.hpp
+++ b/src/HTTP/HTTP2/h2proto.hpp
@@ -37,7 +37,7 @@ class HTTP2 : public std::enable_shared_from_this<HTTP2> {
 
 public:
     [[nodiscard]] task<void> client();
-    HTTP2(std::unique_ptr<stream> stream, std::function<task<bool>(std::shared_ptr<http_ctx>)> handler);
+    HTTP2(std::unique_ptr<stream> stream, std::function< task<bool>(http_ctx& )> handler);
     ~HTTP2();
     HTTP2(const HTTP2&) = delete;
     HTTP2& operator=(const HTTP2&) = delete;
@@ -48,7 +48,7 @@ public:
 
     std::unique_ptr<stream> m_stream;
     friend class h2_stream;
-    std::function<task<bool>(std::shared_ptr<http_ctx>)> m_handler;
+    std::function<task<bool>(http_ctx&)> m_handler;
 private:
     [[nodiscard]] task<bool> connection_startup();
     [[nodiscard]] task<stream_result> send_outbox();

--- a/src/HTTP/HTTP2/h2proto.hpp
+++ b/src/HTTP/HTTP2/h2proto.hpp
@@ -56,10 +56,10 @@ private:
     void handle_frame(h2frame& frame);
     async_mutex m_async_mut;
     uint32_t last_coro_id = 0;
-    std::vector<uint8_t> m_read_buffer; // todo: use deque
+    std::deque<uint8_t> m_read_buffer; // todo: use deque
 };
 
-std::pair<std::unique_ptr<h2frame>, bool> extract_frame(std::vector<uint8_t>& buffer);
+std::pair<std::unique_ptr<h2frame>, bool> extract_frame(std::deque<uint8_t>& buffer);
 
 task<void> handle_stream(std::weak_ptr<HTTP2> connection, uint32_t stream_id);
 

--- a/src/HTTP/HTTP2/h2proto.hpp
+++ b/src/HTTP/HTTP2/h2proto.hpp
@@ -21,6 +21,7 @@
 #include <unordered_map>
 #include <memory>
 #include <string>
+#include <functional>
 
 namespace fbw {
 
@@ -36,20 +37,18 @@ class HTTP2 : public std::enable_shared_from_this<HTTP2> {
 
 public:
     [[nodiscard]] task<void> client();
-    HTTP2(std::unique_ptr<stream> stream, std::string folder);
+    HTTP2(std::unique_ptr<stream> stream, std::function<task<bool>(std::shared_ptr<http_ctx>)> handler);
     ~HTTP2();
     HTTP2(const HTTP2&) = delete;
     HTTP2& operator=(const HTTP2&) = delete;
-
-    task<void> close_connection();
     
     h2_context h2_ctx;
     std::unordered_map<uint32_t, rw_handle> m_coros; // contains all awaiting coroutines
     std::mutex m_coro_mut;
 
     std::unique_ptr<stream> m_stream;
-    std::string m_folder;
     friend class h2_stream;
+    std::function<task<bool>(std::shared_ptr<http_ctx>)> m_handler;
 private:
     [[nodiscard]] task<bool> connection_startup();
     [[nodiscard]] task<stream_result> send_outbox();

--- a/src/HTTP/HTTP2/h2stream.cpp
+++ b/src/HTTP/HTTP2/h2stream.cpp
@@ -85,6 +85,7 @@ std::vector<entry_t> h2_stream::get_headers() {
     }
     auto& cx = connection->h2_ctx;
     auto headers = cx.get_headers(m_stream_id);
+    headers.push_back({":protocol", "h2"}); // todo: use a request headers struct
     return headers;
 }
 

--- a/src/HTTP/HTTP2/h2stream.cpp
+++ b/src/HTTP/HTTP2/h2stream.cpp
@@ -61,7 +61,7 @@ task<std::pair<stream_result, bool>> h2_stream::append_http_data(ustring& buffer
     if(bytes == 0) {
         co_return {stream_result::closed, false};
     }
-    buffer.append(subbuffer.begin(), subbuffer.begin() + bytes);
+    buffer.insert(buffer.end(), subbuffer.begin(), subbuffer.begin() + bytes);
 
     // push window updates
     auto conn = m_connection.lock();

--- a/src/HTTP/HTTP2/h2stream.cpp
+++ b/src/HTTP/HTTP2/h2stream.cpp
@@ -55,7 +55,7 @@ task<stream_result> h2_stream::write_data(std::span<const uint8_t> data, bool en
     co_return stream_resu;
 }
 
-task<std::pair<stream_result, bool>> h2_stream::append_http_data(ustring& buffer) {
+task<std::pair<stream_result, bool>> h2_stream::append_http_data(std::vector<uint8_t>& buffer) {
     std::array<uint8_t, 4096> subbuffer{};
     auto [bytes, data_done] = co_await h2readable(m_connection, m_stream_id, subbuffer);
     if(bytes == 0) {

--- a/src/HTTP/HTTP2/h2stream.cpp
+++ b/src/HTTP/HTTP2/h2stream.cpp
@@ -27,11 +27,6 @@ task<stream_result> h2_stream::write_headers(const std::vector<entry_t>& headers
     if(!conn) {
         co_return stream_result::closed;
     }
-    std::cout << "headers sent: \n";
-    for(auto header : headers) {
-        std::cout << header.name << ": " << header.value << std::endl;
-    }
-    std::cout << "headers sent end" << std::endl;
     bool success = conn->h2_ctx.buffer_headers(headers, m_stream_id);
     if(!success) {
         co_return stream_result::closed;
@@ -55,9 +50,7 @@ task<stream_result> h2_stream::write_data(std::span<const uint8_t> data, bool en
     }
     if(stream_resu == stream_result::awaiting) {
         auto connection_alive = co_await h2writeable(m_connection, m_stream_id);
-        if(connection_alive != stream_result::ok) {
-            co_return connection_alive;
-        }
+        co_return connection_alive;
     }
     co_return stream_resu;
 }

--- a/src/HTTP/HTTP2/h2stream.cpp
+++ b/src/HTTP/HTTP2/h2stream.cpp
@@ -51,6 +51,9 @@ task<stream_result> h2_stream::write_data(std::span<const uint8_t> data, bool en
     if(stream_resu == stream_result::awaiting) {
         auto connection_alive = co_await h2writeable(m_connection, m_stream_id);
         co_return connection_alive;
+    } else if (stream_resu == stream_result::ok) {
+        auto connection_alive = co_await unless_blocking_read(m_connection);
+        co_return connection_alive;
     }
     co_return stream_resu;
 }

--- a/src/HTTP/HTTP2/h2stream.cpp
+++ b/src/HTTP/HTTP2/h2stream.cpp
@@ -14,11 +14,24 @@ h2_stream::h2_stream(std::weak_ptr<HTTP2> connection, uint32_t stream_id) :
     m_connection(connection), m_stream_id(stream_id)
 {}
 
+bool h2_stream::is_done() {
+    auto conn = m_connection.lock();
+    if(!conn) {
+        return true;
+    }
+    return conn->h2_ctx.is_closed(m_stream_id) == stream_result::closed;
+}
+
 task<stream_result> h2_stream::write_headers(const std::vector<entry_t>& headers) {
     auto conn = m_connection.lock();
     if(!conn) {
         co_return stream_result::closed;
     }
+    std::cout << "headers sent: \n";
+    for(auto header : headers) {
+        std::cout << header.name << ": " << header.value << std::endl;
+    }
+    std::cout << "headers sent end" << std::endl;
     bool success = conn->h2_ctx.buffer_headers(headers, m_stream_id);
     if(!success) {
         co_return stream_result::closed;
@@ -32,18 +45,21 @@ task<stream_result> h2_stream::write_data(std::span<const uint8_t> data, bool en
         co_return stream_result::closed;
     }
     assert(conn);
-    auto suspend = conn->h2_ctx.buffer_data(data, m_stream_id, end);
+    if(conn->h2_ctx.is_closed(m_stream_id) == stream_result::closed) {
+        co_return stream_result::closed;
+    }
+    auto stream_resu = conn->h2_ctx.buffer_data(data, m_stream_id, end);
     auto res = co_await conn->send_outbox();
     if(res != stream_result::ok) {
         co_return res;
     }
-    if(suspend) {
+    if(stream_resu == stream_result::awaiting) {
         auto connection_alive = co_await h2writeable(m_connection, m_stream_id);
         if(connection_alive != stream_result::ok) {
             co_return connection_alive;
         }
     }
-    co_return stream_result::ok;
+    co_return stream_resu;
 }
 
 task<std::pair<stream_result, bool>> h2_stream::append_http_data(ustring& buffer) {
@@ -72,7 +88,13 @@ std::vector<entry_t> h2_stream::get_headers() {
         return {};
     }
     auto& cx = connection->h2_ctx;
-    return cx.get_headers(m_stream_id);
+    auto headers = cx.get_headers(m_stream_id);
+    std::cout << "headers received: \n";
+    for(auto header : headers) {
+        std::cout << header.name << ": " << header.value << std::endl;
+    }
+    std::cout << "headers received end" << std::endl;
+    return headers;
 }
 
 }

--- a/src/HTTP/HTTP2/h2stream.cpp
+++ b/src/HTTP/HTTP2/h2stream.cpp
@@ -19,7 +19,7 @@ bool h2_stream::is_done() {
     if(!conn) {
         return true;
     }
-    return conn->h2_ctx.is_closed(m_stream_id) == stream_result::closed;
+    return conn->h2_ctx.stream_status(m_stream_id) == stream_result::closed;
 }
 
 task<stream_result> h2_stream::write_headers(const std::vector<entry_t>& headers) {
@@ -40,7 +40,7 @@ task<stream_result> h2_stream::write_data(std::span<const uint8_t> data, bool en
         co_return stream_result::closed;
     }
     assert(conn);
-    if(conn->h2_ctx.is_closed(m_stream_id) == stream_result::closed) {
+    if(conn->h2_ctx.stream_status(m_stream_id) == stream_result::closed) {
         co_return stream_result::closed;
     }
     auto stream_resu = conn->h2_ctx.buffer_data(data, m_stream_id, end);

--- a/src/HTTP/HTTP2/h2stream.cpp
+++ b/src/HTTP/HTTP2/h2stream.cpp
@@ -55,7 +55,7 @@ task<stream_result> h2_stream::write_data(std::span<const uint8_t> data, bool en
     co_return stream_resu;
 }
 
-task<std::pair<stream_result, bool>> h2_stream::append_http_data(std::vector<uint8_t>& buffer) {
+task<std::pair<stream_result, bool>> h2_stream::append_http_data(std::deque<uint8_t>& buffer) {
     std::array<uint8_t, 4096> subbuffer{};
     auto [bytes, data_done] = co_await h2readable(m_connection, m_stream_id, subbuffer);
     if(bytes == 0) {

--- a/src/HTTP/HTTP2/h2stream.cpp
+++ b/src/HTTP/HTTP2/h2stream.cpp
@@ -89,11 +89,6 @@ std::vector<entry_t> h2_stream::get_headers() {
     }
     auto& cx = connection->h2_ctx;
     auto headers = cx.get_headers(m_stream_id);
-    std::cout << "headers received: \n";
-    for(auto header : headers) {
-        std::cout << header.name << ": " << header.value << std::endl;
-    }
-    std::cout << "headers received end" << std::endl;
     return headers;
 }
 

--- a/src/HTTP/HTTP2/h2stream.hpp
+++ b/src/HTTP/HTTP2/h2stream.hpp
@@ -26,7 +26,7 @@ public:
     std::vector<entry_t> get_headers() override;
     task<stream_result> write_headers(const std::vector<entry_t>& headers) override;
     task<stream_result> write_data(std::span<const uint8_t> data, bool end = false) override;
-    task<std::pair<stream_result, bool>> append_http_data(std::vector<uint8_t>& buffer) override;
+    task<std::pair<stream_result, bool>> append_http_data(std::deque<uint8_t>& buffer) override;
     bool is_done() override;
 
     h2_stream(std::weak_ptr<HTTP2> connection, uint32_t stream_id);

--- a/src/HTTP/HTTP2/h2stream.hpp
+++ b/src/HTTP/HTTP2/h2stream.hpp
@@ -25,8 +25,9 @@ public:
 
     std::vector<entry_t> get_headers() override;
     task<stream_result> write_headers(const std::vector<entry_t>& headers) override;
-    task<stream_result> write_data(std::span<const uint8_t> data, bool end = true) override;
+    task<stream_result> write_data(std::span<const uint8_t> data, bool end = false) override;
     task<std::pair<stream_result, bool>> append_http_data(ustring& buffer) override;
+    bool is_done() override;
 
     h2_stream(std::weak_ptr<HTTP2> connection, uint32_t stream_id);
 private:

--- a/src/HTTP/HTTP2/h2stream.hpp
+++ b/src/HTTP/HTTP2/h2stream.hpp
@@ -26,7 +26,7 @@ public:
     std::vector<entry_t> get_headers() override;
     task<stream_result> write_headers(const std::vector<entry_t>& headers) override;
     task<stream_result> write_data(std::span<const uint8_t> data, bool end = false) override;
-    task<std::pair<stream_result, bool>> append_http_data(ustring& buffer) override;
+    task<std::pair<stream_result, bool>> append_http_data(std::vector<uint8_t>& buffer) override;
     bool is_done() override;
 
     h2_stream(std::weak_ptr<HTTP2> connection, uint32_t stream_id);

--- a/src/HTTP/HTTP2/hpack.cpp
+++ b/src/HTTP/HTTP2/hpack.cpp
@@ -105,6 +105,7 @@ ustring hpack::generate_field_block_fragment(const std::vector<entry_t>& headers
         m_encode_table.set_capacity(encoder_max_capacity);
     }
     for (const auto& header : headers) {
+        // todo: tolower case
         auto index = m_encode_table.index(header);
         if (index != 0) {
             encoded_fragment.append(indexed_field(index));
@@ -314,6 +315,8 @@ ustring encode_integer(uint32_t value, uint8_t prefix_bits) {
 }
 
 uint32_t decode_integer(const ustring& encoded, size_t& offset, uint8_t prefix_bits) {
+    // todo: if an encoding has leading zeros, it might not be the most efficient encoding
+    // and we should throw in this case
     uint32_t prefix = (1 << prefix_bits) - 1;
     if(offset >= encoded.size()) {
         throw h2_error("bounds check", h2_code::COMPRESSION_ERROR);

--- a/src/HTTP/HTTP2/hpack.hpp
+++ b/src/HTTP/HTTP2/hpack.hpp
@@ -82,8 +82,8 @@ public:
 
     void set_encoder_max_capacity(uint32_t);
     void set_decoder_max_capacity(uint32_t);
-    std::vector<entry_t> parse_field_block_fragment(const ustring& field_block_fragment);
-    ustring generate_field_block_fragment(const std::vector<entry_t>& headers);
+    std::vector<entry_t> parse_field_block(const ustring& field_block_fragment);
+    ustring generate_field_block(const std::vector<entry_t>& headers);
 };
 
 }

--- a/src/HTTP/HTTP2/hpack.hpp
+++ b/src/HTTP/HTTP2/hpack.hpp
@@ -51,8 +51,6 @@ struct logged_entry {
 
 class table { // todo consider structure
     using cont_t = std::deque<logged_entry>;
-    std::unordered_map<entry_t, cont_t::iterator> lookup_idx;
-    std::unordered_map<size_t, cont_t::iterator> lookup_field;
     cont_t entries_ordered;
     
     size_t m_size = 0;
@@ -63,7 +61,8 @@ public:
     table();
     size_t m_capacity = 4096;
     void set_capacity(size_t capacity);
-    size_t index(const entry_t& entry);
+    size_t index(entry_t entry);
+    size_t name_index(const std::string& entry);
     std::optional<entry_t> field(size_t entry);
     void add_entry(const entry_t& entry);
 };

--- a/src/HTTP/HTTP2/hpack.hpp
+++ b/src/HTTP/HTTP2/hpack.hpp
@@ -74,16 +74,16 @@ private:
     table m_encode_table;
     table m_decode_table;
 
-    std::optional<entry_t> decode_hpack_string(const ustring& data, size_t& offset);
-    entry_t extract_entry(size_t idx, do_indexing do_index, const ustring& encoded, size_t& offset);
+    std::optional<entry_t> decode_hpack_string(const std::vector<uint8_t>& data, size_t& offset);
+    entry_t extract_entry(size_t idx, do_indexing do_index, const std::vector<uint8_t>& encoded, size_t& offset);
 public:
     size_t encoder_max_capacity = 4096;
     size_t decoder_max_capacity = 4096;
 
     void set_encoder_max_capacity(uint32_t);
     void set_decoder_max_capacity(uint32_t);
-    std::vector<entry_t> parse_field_block(const ustring& field_block_fragment);
-    ustring generate_field_block(const std::vector<entry_t>& headers);
+    std::vector<entry_t> parse_field_block(const std::vector<uint8_t>& field_block_fragment);
+    std::vector<uint8_t> generate_field_block(const std::vector<entry_t>& headers);
 };
 
 }

--- a/src/HTTP/http_ctx.hpp
+++ b/src/HTTP/http_ctx.hpp
@@ -49,7 +49,8 @@ public:
     virtual task<std::pair<stream_result, bool>> append_http_data(ustring& buffer) = 0; // bool end
     virtual task<stream_result> write_headers(const std::vector<entry_t>& headers) = 0;
     //virtual task<stream_result> write_push_promise(std::vector<entry_t>& headers) = 0;
-    virtual task<stream_result> write_data(std::span<const uint8_t> data, bool end = true) = 0;
+    virtual task<stream_result> write_data(std::span<const uint8_t> data, bool end = false) = 0;
+    virtual bool is_done() = 0;
     virtual ~http_ctx() = default;
 };
 

--- a/src/HTTP/http_ctx.hpp
+++ b/src/HTTP/http_ctx.hpp
@@ -46,7 +46,7 @@ namespace fbw {
 class http_ctx {
 public:
     virtual std::vector<entry_t> get_headers() = 0;
-    virtual task<std::pair<stream_result, bool>> append_http_data(std::vector<uint8_t>& buffer) = 0; // bool end
+    virtual task<std::pair<stream_result, bool>> append_http_data(std::deque<uint8_t>& buffer) = 0; // bool end
     virtual task<stream_result> write_headers(const std::vector<entry_t>& headers) = 0;
     //virtual task<stream_result> write_push_promise(std::vector<entry_t>& headers) = 0;
     virtual task<stream_result> write_data(std::span<const uint8_t> data, bool end = false) = 0;

--- a/src/HTTP/http_ctx.hpp
+++ b/src/HTTP/http_ctx.hpp
@@ -46,7 +46,7 @@ namespace fbw {
 class http_ctx {
 public:
     virtual std::vector<entry_t> get_headers() = 0;
-    virtual task<std::pair<stream_result, bool>> append_http_data(ustring& buffer) = 0; // bool end
+    virtual task<std::pair<stream_result, bool>> append_http_data(std::vector<uint8_t>& buffer) = 0; // bool end
     virtual task<stream_result> write_headers(const std::vector<entry_t>& headers) = 0;
     //virtual task<stream_result> write_push_promise(std::vector<entry_t>& headers) = 0;
     virtual task<stream_result> write_data(std::span<const uint8_t> data, bool end = false) = 0;

--- a/src/TCP/Awaitables/await_stream.cpp
+++ b/src/TCP/Awaitables/await_stream.cpp
@@ -36,6 +36,10 @@ bool readable::await_suspend(std::coroutine_handle<> continuation) {
     }
     if(succ < 0) {
         if(errno == EWOULDBLOCK or errno == EAGAIN) {
+            if(m_millis == 0ms) {
+                m_res = stream_result::read_timeout;
+                return false;
+            }
             auto& exec = executor_singleton();
             exec.m_reactor.add_task(m_fd, continuation, IO_direction::Read, m_millis);
             m_res = stream_result::awaiting;

--- a/src/TCP/Awaitables/await_stream.cpp
+++ b/src/TCP/Awaitables/await_stream.cpp
@@ -87,15 +87,15 @@ bool writeable::await_ready() const noexcept {
 
 bool writeable::await_suspend(std::coroutine_handle<> continuation) {
     // process a few records before moving onto the next client
-    static std::atomic<size_t> fail_sometimes = 1;
-    size_t local_value = fail_sometimes.fetch_add(1, std::memory_order_relaxed);
-    local_value %= 10;
-    if(local_value == 0) {
-        m_res = stream_result::awaiting;
-        auto& exec = executor_singleton();
-        exec.m_reactor.add_task(m_fd, continuation, IO_direction::Write, m_millis);
-        return true;
-    }
+    //static std::atomic<size_t> fail_sometimes = 1;
+    //size_t local_value = fail_sometimes.fetch_add(1, std::memory_order_relaxed);
+    //local_value %= 10;
+    //if(local_value == 0) {
+    //    m_res = stream_result::awaiting;
+    //    auto& exec = executor_singleton();
+    //    exec.m_reactor.add_task(m_fd, continuation, IO_direction::Write, m_millis);
+    //    return true;
+    //}
     assert(m_fd != -1);
     assert(m_buffer);
     ssize_t succ = ::send(m_fd, m_buffer->data(), m_buffer->size(), MSG_NOSIGNAL);

--- a/src/TCP/stream_base.hpp
+++ b/src/TCP/stream_base.hpp
@@ -45,7 +45,6 @@ public:
     // returns true if stream is still open on read
     [[nodiscard]] virtual task<stream_result> read_append(ustring&, std::optional<milliseconds> timeout) = 0;
     [[nodiscard]] virtual task<stream_result> write(ustring, std::optional<milliseconds> timeout) = 0;
-    [[nodiscard]] virtual task<stream_result> flush() = 0;
 
     [[nodiscard]] virtual task<void> close_notify() = 0;
     virtual ~stream() noexcept = default;

--- a/src/TCP/stream_base.hpp
+++ b/src/TCP/stream_base.hpp
@@ -15,7 +15,7 @@
 #include "../Runtime/task.hpp"
 #include <chrono>
 #include <optional>
-
+#include <deque>
 
 
 namespace fbw {

--- a/src/TCP/stream_base.hpp
+++ b/src/TCP/stream_base.hpp
@@ -43,8 +43,8 @@ class stream {
 public:
     stream() = default;
     // returns true if stream is still open on read
-    [[nodiscard]] virtual task<stream_result> read_append(ustring&, std::optional<milliseconds> timeout) = 0;
-    [[nodiscard]] virtual task<stream_result> write(ustring, std::optional<milliseconds> timeout) = 0;
+    [[nodiscard]] virtual task<stream_result> read_append(std::vector<uint8_t>&, std::optional<milliseconds> timeout) = 0;
+    [[nodiscard]] virtual task<stream_result> write(std::vector<uint8_t>, std::optional<milliseconds> timeout) = 0;
 
     [[nodiscard]] virtual task<void> close_notify() = 0;
     virtual ~stream() noexcept = default;

--- a/src/TCP/stream_base.hpp
+++ b/src/TCP/stream_base.hpp
@@ -43,7 +43,7 @@ class stream {
 public:
     stream() = default;
     // returns true if stream is still open on read
-    [[nodiscard]] virtual task<stream_result> read_append(std::vector<uint8_t>&, std::optional<milliseconds> timeout) = 0;
+    [[nodiscard]] virtual task<stream_result> read_append(std::deque<uint8_t>&, std::optional<milliseconds> timeout) = 0;
     [[nodiscard]] virtual task<stream_result> write(std::vector<uint8_t>, std::optional<milliseconds> timeout) = 0;
 
     [[nodiscard]] virtual task<void> close_notify() = 0;

--- a/src/TCP/tcp_stream.cpp
+++ b/src/TCP/tcp_stream.cpp
@@ -10,10 +10,11 @@
 
 #include <unistd.h>
 #include <utility>
+#include <deque>
 
 namespace fbw {
 
-task<stream_result> tcp_stream::read_append(std::vector<uint8_t>& abuffer, std::optional<milliseconds> timeout) {
+task<stream_result> tcp_stream::read_append(std::deque<uint8_t>& abuffer, std::optional<milliseconds> timeout) {
     std::array<uint8_t, 8192> readbuff;
     std::span<uint8_t> remaining_buffer = { readbuff.data(), readbuff.size() };
     auto [bytes_read, status] = co_await read(remaining_buffer, timeout);

--- a/src/TCP/tcp_stream.cpp
+++ b/src/TCP/tcp_stream.cpp
@@ -34,10 +34,6 @@ task<stream_result> tcp_stream::write(ustring abuffer, std::optional<millisecond
     co_return stream_result::ok;
 }
 
-[[nodiscard]] task<stream_result> tcp_stream::flush() {
-    co_return stream_result::ok;
-}
-
 tcp_stream::tcp_stream(int fd, std::string ip, uint16_t port) : stream(), m_ip(ip), m_port(port), m_fd(fd) { }
 
 readable tcp_stream::read(std::span<uint8_t>& bytes, std::optional<milliseconds> timeout) {

--- a/src/TCP/tcp_stream.cpp
+++ b/src/TCP/tcp_stream.cpp
@@ -18,7 +18,7 @@ task<stream_result> tcp_stream::read_append(ustring& abuffer, std::optional<mill
     std::span<uint8_t> remaining_buffer = { readbuff.data(), readbuff.size() };
     auto [bytes_read, status] = co_await read(remaining_buffer, timeout);
     if (status == stream_result::ok) [[likely]] {
-        abuffer.append(bytes_read.begin(), bytes_read.end());
+        abuffer.insert(abuffer.end(), bytes_read.begin(), bytes_read.end());
     }
     co_return status;
 }

--- a/src/TCP/tcp_stream.cpp
+++ b/src/TCP/tcp_stream.cpp
@@ -13,7 +13,7 @@
 
 namespace fbw {
 
-task<stream_result> tcp_stream::read_append(ustring& abuffer, std::optional<milliseconds> timeout) {
+task<stream_result> tcp_stream::read_append(std::vector<uint8_t>& abuffer, std::optional<milliseconds> timeout) {
     std::array<uint8_t, 8192> readbuff;
     std::span<uint8_t> remaining_buffer = { readbuff.data(), readbuff.size() };
     auto [bytes_read, status] = co_await read(remaining_buffer, timeout);
@@ -23,7 +23,7 @@ task<stream_result> tcp_stream::read_append(ustring& abuffer, std::optional<mill
     co_return status;
 }
 
-task<stream_result> tcp_stream::write(ustring abuffer, std::optional<milliseconds> timeout) {
+task<stream_result> tcp_stream::write(std::vector<uint8_t> abuffer, std::optional<milliseconds> timeout) {
     std::span<const uint8_t> remaining_buffer = {abuffer.data(), abuffer.size()};
     while(remaining_buffer.size() != 0) {
         auto [_, status] = co_await write_some(remaining_buffer, timeout);

--- a/src/TCP/tcp_stream.hpp
+++ b/src/TCP/tcp_stream.hpp
@@ -13,6 +13,7 @@
 #include <chrono>
 #include <optional>
 #include <string>
+#include <deque>
 
 #include "../global.hpp"
 #include "stream_base.hpp"
@@ -34,7 +35,7 @@ public:
     tcp_stream(tcp_stream&& other);
     tcp_stream& operator=(tcp_stream&& other);
     
-    [[nodiscard]] task<stream_result> read_append(std::vector<uint8_t>&, std::optional<milliseconds> timeout) override;
+    [[nodiscard]] task<stream_result> read_append(std::deque<uint8_t>&, std::optional<milliseconds> timeout) override;
     [[nodiscard]] task<stream_result> write(std::vector<uint8_t>, std::optional<milliseconds> timeout) override;
     [[nodiscard]] task<void> close_notify() override;
 

--- a/src/TCP/tcp_stream.hpp
+++ b/src/TCP/tcp_stream.hpp
@@ -37,7 +37,6 @@ public:
     [[nodiscard]] task<stream_result> read_append(ustring&, std::optional<milliseconds> timeout) override;
     [[nodiscard]] task<stream_result> write(ustring, std::optional<milliseconds> timeout) override;
     [[nodiscard]] task<void> close_notify() override;
-    [[nodiscard]] task<stream_result> flush() override;
 
     std::string m_ip;
     uint16_t m_port;

--- a/src/TCP/tcp_stream.hpp
+++ b/src/TCP/tcp_stream.hpp
@@ -34,8 +34,8 @@ public:
     tcp_stream(tcp_stream&& other);
     tcp_stream& operator=(tcp_stream&& other);
     
-    [[nodiscard]] task<stream_result> read_append(ustring&, std::optional<milliseconds> timeout) override;
-    [[nodiscard]] task<stream_result> write(ustring, std::optional<milliseconds> timeout) override;
+    [[nodiscard]] task<stream_result> read_append(std::vector<uint8_t>&, std::optional<milliseconds> timeout) override;
+    [[nodiscard]] task<stream_result> write(std::vector<uint8_t>, std::optional<milliseconds> timeout) override;
     [[nodiscard]] task<void> close_notify() override;
 
     std::string m_ip;

--- a/src/TLS/Cryptography/assymetric/secp256r1.cpp
+++ b/src/TLS/Cryptography/assymetric/secp256r1.cpp
@@ -380,19 +380,19 @@ ECDSA_signature ECDSA_impl(const ct_u256& k_random, const ct_u256& digest, const
     return {r, s};
 }
 
-ustring raw_ECDSA(std::array<uint8_t,32> k_random,
+std::vector<uint8_t> raw_ECDSA(std::array<uint8_t,32> k_random,
                      std::array<uint8_t,32> digest,
                      std::array<uint8_t,32> private_key) {
     auto signature = ECDSA_impl(std::move(k_random), std::move(digest), std::move(private_key));
     auto r = signature.r.serialise();
     auto s = signature.s.serialise();
-    ustring out;
+    std::vector<uint8_t> out;
     out.insert(out.end(), r.begin(), r.end());
     out.insert(out.end(), s.begin(), s.end());
     return out;
 }
 
-ustring DER_ECDSA(
+std::vector<uint8_t> DER_ECDSA(
                      std::array<uint8_t,32> k_random,
                      std::array<uint8_t,32> digest,
                      std::array<uint8_t,32> private_key) {
@@ -402,7 +402,7 @@ ustring DER_ECDSA(
     auto s = signature.s.serialise();
     
 
-    ustring out;
+    std::vector<uint8_t> out;
     out.insert(out.end(), {0x30,0x00, 0x02});
     
     if(r[0]&0x80) {

--- a/src/TLS/Cryptography/assymetric/secp256r1.cpp
+++ b/src/TLS/Cryptography/assymetric/secp256r1.cpp
@@ -387,8 +387,8 @@ ustring raw_ECDSA(std::array<uint8_t,32> k_random,
     auto r = signature.r.serialise();
     auto s = signature.s.serialise();
     ustring out;
-    out.append(r.begin(), r.end());
-    out.append(s.begin(), s.end());
+    out.insert(out.end(), r.begin(), r.end());
+    out.insert(out.end(), s.begin(), s.end());
     return out;
 }
 
@@ -403,21 +403,21 @@ ustring DER_ECDSA(
     
 
     ustring out;
-    out.append({0x30,0x00, 0x02});
+    out.insert(out.end(), {0x30,0x00, 0x02});
     
     if(r[0]&0x80) {
-        out.append({0x21,0x00});
+        out.insert(out.end(), {0x21,0x00});
     } else {
-        out.append({0x20});
+        out.insert(out.end(),{0x20});
     }
-    out.append(r.cbegin(),r.cend());
-    out.append({0x02});
+    out.insert(out.end(),r.cbegin(),r.cend());
+    out.insert(out.end(), {0x02});
     if(s[0]&0x80) {
-        out.append({0x21,0x00});
+        out.insert(out.end(), {0x21,0x00});
     } else {
-        out.append({0x20});
+        out.insert(out.end(), {0x20});
     }
-    out.append(s.cbegin(),s.cend());
+    out.insert(out.end(), s.cbegin(),s.cend());
     assert(out.size() >= 2);
     assert(out.size() < 256);
     out[1] = static_cast<uint8_t>(out.size()-2);

--- a/src/TLS/Cryptography/assymetric/secp256r1.hpp
+++ b/src/TLS/Cryptography/assymetric/secp256r1.hpp
@@ -20,7 +20,7 @@ constexpr size_t PRIVKEY_SIZE = 32;
 constexpr size_t SECRET_SIZE = 32;
 
 // Signs the message digest with the certificates privte key and a secret random number in DER encoded format
-[[nodiscard]] ustring DER_ECDSA(
+[[nodiscard]] std::vector<uint8_t> DER_ECDSA(
                      std::array<uint8_t,32> k_random,
                      std::array<uint8_t, 32> digest,
                       std::array<uint8_t, PRIVKEY_SIZE> private_key);

--- a/src/TLS/Cryptography/cipher/block_chain.cpp
+++ b/src/TLS/Cryptography/cipher/block_chain.cpp
@@ -27,7 +27,7 @@ AES_CBC_SHA::AES_CBC_SHA() : server_write_round_keys({}),
                                             seqno_client(0) { }
 
 
-void AES_CBC_SHA::set_key_material_12(ustring expanded_master)  {
+void AES_CBC_SHA::set_key_material_12(std::vector<uint8_t> expanded_master)  {
     assert(expanded_master.size() >= 104);
 
     auto client_write_key = std::vector<uint8_t>(16,0);
@@ -49,7 +49,7 @@ void AES_CBC_SHA::set_key_material_12(ustring expanded_master)  {
 }
 
 
-ustring pad_message(ustring message) {
+std::vector<uint8_t> pad_message(std::vector<uint8_t> message) {
     const auto blocksize = 16;
     const auto padmax = 256;
     
@@ -89,7 +89,7 @@ tls_record AES_CBC_SHA::protect(tls_record record) noexcept {
     std::array<uint8_t, 16> record_IV {};
     randomgen.randgen(record_IV);
     record.m_contents = pad_message(std::move(record.m_contents));
-    ustring out;
+    std::vector<uint8_t> out;
     out.assign(record_IV.cbegin(),record_IV.cend());
     auto in_block = record_IV;
     for(size_t i = 0; i < record.m_contents.size(); i += 16) {
@@ -108,7 +108,7 @@ tls_record AES_CBC_SHA::deprotect(tls_record record) {
         throw ssl_error("bad encrypted record length", AlertLevel::fatal, AlertDescription::decrypt_error);
     }
 
-    ustring plaintext;
+    std::vector<uint8_t> plaintext;
     std::array<uint8_t, 16> record_IV {};
     constexpr auto blocksize = record_IV.size();
     

--- a/src/TLS/Cryptography/cipher/block_chain.hpp
+++ b/src/TLS/Cryptography/cipher/block_chain.hpp
@@ -30,7 +30,7 @@ private:
 public:
     AES_CBC_SHA();
     
-    void set_key_material_12(ustring material) override;
+    void set_key_material_12(std::vector<uint8_t> material) override;
     tls_record protect(tls_record record) noexcept override;
     tls_record deprotect(tls_record record) override;
 };

--- a/src/TLS/Cryptography/cipher/chacha20poly1305.cpp
+++ b/src/TLS/Cryptography/cipher/chacha20poly1305.cpp
@@ -245,7 +245,7 @@ chacha20_aead_crypt(const std::span<const uint8_t> aad, const std::array<uint8_t
     }
 
     size_t padcipher = ((text.size()+15)/16)*16 - text.size();
-    ustring mac_data;
+    std::vector<uint8_t> mac_data;
     mac_data.insert(mac_data.end(), aad.begin(), aad.end());
     mac_data.insert(mac_data.end(), padaad, 0);
 
@@ -266,7 +266,7 @@ chacha20_aead_crypt(const std::span<const uint8_t> aad, const std::array<uint8_t
     return tag;
 }
 
-void ChaCha20_Poly1305_tls13::set_server_traffic_key(const ustring& traffic_key) {
+void ChaCha20_Poly1305_tls13::set_server_traffic_key(const std::vector<uint8_t>& traffic_key) {
     auto key = hkdf_expand_label(sha256(), traffic_key, "key", std::string(""), KEY_SIZE);
     auto iv = hkdf_expand_label(sha256(), traffic_key, "iv", std::string(""), IV_SIZE);
     std::copy(key.begin(), key.end(), ctx.server_write_key.begin());
@@ -274,7 +274,7 @@ void ChaCha20_Poly1305_tls13::set_server_traffic_key(const ustring& traffic_key)
     ctx.seqno_server = 0;
 }
 
-void ChaCha20_Poly1305_tls13::set_client_traffic_key(const ustring& traffic_key) {
+void ChaCha20_Poly1305_tls13::set_client_traffic_key(const std::vector<uint8_t>& traffic_key) {
     auto key = hkdf_expand_label(sha256(), traffic_key, "key", std::string(""), KEY_SIZE);
     auto iv = hkdf_expand_label(sha256(), traffic_key, "iv", std::string(""), IV_SIZE);
     std::copy(key.begin(), key.end(), ctx.client_write_key.begin());
@@ -282,7 +282,7 @@ void ChaCha20_Poly1305_tls13::set_client_traffic_key(const ustring& traffic_key)
     ctx.seqno_client = 0;
 }
 
-void ChaCha20_Poly1305_tls12::set_key_material_12(ustring material) {
+void ChaCha20_Poly1305_tls12::set_key_material_12(std::vector<uint8_t> material) {
     
     auto it = material.begin();
     std::copy_n(it, ctx.client_write_key.size(), ctx.client_write_key.begin());
@@ -295,10 +295,10 @@ void ChaCha20_Poly1305_tls12::set_key_material_12(ustring material) {
     it += ctx.server_implicit_write_IV.size();
 }
 
-ustring make_additional_12(tls_record& record, uint64_t sequence_no, size_t tag_size) {
+std::vector<uint8_t> make_additional_12(tls_record& record, uint64_t sequence_no, size_t tag_size) {
     assert(record.m_contents.size() >= tag_size);
     uint16_t msglen = htons(record.m_contents.size() - tag_size);
-    ustring additional_data(8, 0);
+    std::vector<uint8_t> additional_data(8, 0);
     checked_bigend_write(sequence_no, additional_data, 0, 8);
     additional_data.insert(additional_data.end(), {static_cast<uint8_t>(record.get_type()), record.get_major_version(), record.get_minor_version()});
     additional_data.resize(13);
@@ -315,17 +315,17 @@ std::array<uint8_t, IV_SIZE> make_number_once(std::array<uint8_t, IV_SIZE> IV, u
     return IV;
 }
 
-ustring ChaCha20_Poly1305_ctx::encrypt(const std::span<uint8_t> text, const ustring& additional_data) {
+std::vector<uint8_t> ChaCha20_Poly1305_ctx::encrypt(const std::span<uint8_t> text, const std::vector<uint8_t>& additional_data) {
     auto number_once = make_number_once(server_implicit_write_IV, seqno_server);
     seqno_server++;
     auto tag = chacha20_aead_crypt(additional_data, server_write_key, number_once, text, true);
-    ustring ciphertext;
+    std::vector<uint8_t> ciphertext;
     ciphertext.insert(ciphertext.end(), text.begin(), text.end());
     ciphertext.insert(ciphertext.end(), tag.begin(), tag.end());
     return ciphertext;
 }
 
-ustring ChaCha20_Poly1305_ctx::decrypt(ustring ciphertext, const ustring& additional_data) {
+std::vector<uint8_t> ChaCha20_Poly1305_ctx::decrypt(std::vector<uint8_t> ciphertext, const std::vector<uint8_t>& additional_data) {
     assert(ciphertext.size() >= TAG_SIZE);
     std::array<uint8_t, TAG_SIZE> tag;
     std::copy(ciphertext.end() - TAG_SIZE, ciphertext.end(), tag.begin());
@@ -344,13 +344,13 @@ ustring ChaCha20_Poly1305_ctx::decrypt(ustring ciphertext, const ustring& additi
 
 tls_record ChaCha20_Poly1305_tls13::protect(tls_record record) noexcept {
     record = wrap13(std::move(record));
-    ustring additional_data = make_additional_13(record.m_contents, TAG_SIZE);
+    std::vector<uint8_t> additional_data = make_additional_13(record.m_contents, TAG_SIZE);
     record.m_contents = ctx.encrypt(record.m_contents, additional_data);
     return record;
 }
 
 tls_record ChaCha20_Poly1305_tls12::protect(tls_record record) noexcept {
-    ustring additional_data = make_additional_12(record, ctx.seqno_server, 0);
+    std::vector<uint8_t> additional_data = make_additional_12(record, ctx.seqno_server, 0);
     record.m_contents = ctx.encrypt(record.m_contents, additional_data);
     return record;
 }
@@ -359,7 +359,7 @@ tls_record ChaCha20_Poly1305_tls13::deprotect(tls_record record) {
     if(record.m_contents.size() < TAG_SIZE) {
         throw ssl_error("short record Poly1305", AlertLevel::fatal, AlertDescription::decrypt_error);
     }
-    ustring additional_data = make_additional_13(record.m_contents, 0);
+    std::vector<uint8_t> additional_data = make_additional_13(record.m_contents, 0);
     record.m_contents = ctx.decrypt(std::move(record.m_contents), additional_data);
     record = unwrap13(std::move(record));
     return record;
@@ -369,7 +369,7 @@ tls_record ChaCha20_Poly1305_tls12::deprotect(tls_record record) {
     if(record.m_contents.size() < TAG_SIZE) {
         throw ssl_error("short record Poly1305", AlertLevel::fatal, AlertDescription::decrypt_error);
     }
-    ustring additional_data = make_additional_12(record, ctx.seqno_client, TAG_SIZE);
+    std::vector<uint8_t> additional_data = make_additional_12(record, ctx.seqno_client, TAG_SIZE);
     record.m_contents = ctx.decrypt(record.m_contents, additional_data);
     return record;
 }

--- a/src/TLS/Cryptography/cipher/chacha20poly1305.hpp
+++ b/src/TLS/Cryptography/cipher/chacha20poly1305.hpp
@@ -30,8 +30,8 @@ struct ChaCha20_Poly1305_ctx {
     std::array<uint8_t, IV_SIZE> server_implicit_write_IV;
     uint64_t seqno_server = 0;
     uint64_t seqno_client = 0;
-    ustring encrypt(const std::span<uint8_t> plaintext, const ustring& additional_data);
-    ustring decrypt(ustring ciphertext, const ustring& additional_data);
+    std::vector<uint8_t> encrypt(const std::span<uint8_t> plaintext, const std::vector<uint8_t>& additional_data);
+    std::vector<uint8_t> decrypt(std::vector<uint8_t> ciphertext, const std::vector<uint8_t>& additional_data);
 };
 
 class ChaCha20_Poly1305_tls13 : public cipher_base_tls13 {
@@ -39,8 +39,8 @@ private:
     ChaCha20_Poly1305_ctx ctx;
 public:
     ChaCha20_Poly1305_tls13() = default;
-    void set_server_traffic_key(const ustring& key) override;
-    void set_client_traffic_key(const ustring& key) override;
+    void set_server_traffic_key(const std::vector<uint8_t>& key) override;
+    void set_client_traffic_key(const std::vector<uint8_t>& key) override;
     bool do_key_reset() override;
     tls_record protect(tls_record record) noexcept override;
     tls_record deprotect(tls_record record) override;
@@ -51,7 +51,7 @@ private:
     ChaCha20_Poly1305_ctx ctx;
 public:
     ChaCha20_Poly1305_tls12() = default;
-    void set_key_material_12(ustring material) override;
+    void set_key_material_12(std::vector<uint8_t> material) override;
     tls_record protect(tls_record record) noexcept override;
     tls_record deprotect(tls_record record) override;
 };

--- a/src/TLS/Cryptography/cipher/cipher_base.cpp
+++ b/src/TLS/Cryptography/cipher/cipher_base.cpp
@@ -39,8 +39,8 @@ tls_record unwrap13(tls_record record) {
     return record;
 }
 
-ustring make_additional_13(const ustring& message, size_t tag_size) {
-    ustring additional_data { 0x17, 0x03, 0x03, 0, 0};
+std::vector<uint8_t> make_additional_13(const std::vector<uint8_t>& message, size_t tag_size) {
+    std::vector<uint8_t> additional_data { 0x17, 0x03, 0x03, 0, 0};
     auto size = message.size();
     size += tag_size;
     checked_bigend_write(size, additional_data, 3, 2);

--- a/src/TLS/Cryptography/cipher/cipher_base.hpp
+++ b/src/TLS/Cryptography/cipher/cipher_base.hpp
@@ -26,13 +26,13 @@ public:
 
 class cipher_base_tls12 : public cipher_base {
 public:
-    virtual void set_key_material_12(ustring material) = 0;
+    virtual void set_key_material_12(std::vector<uint8_t> material) = 0;
 };
 
 class cipher_base_tls13 : public cipher_base {
 public:
-    virtual void set_server_traffic_key(const ustring& key) = 0;
-    virtual void set_client_traffic_key(const ustring& key) = 0;
+    virtual void set_server_traffic_key(const std::vector<uint8_t>& key) = 0;
+    virtual void set_client_traffic_key(const std::vector<uint8_t>& key) = 0;
     virtual bool do_key_reset() { return false; }
 };
 
@@ -40,7 +40,7 @@ public:
 
 tls_record wrap13(tls_record record);
 tls_record unwrap13(tls_record record);
-ustring make_additional_13(const ustring& record, size_t tag_size);
+std::vector<uint8_t> make_additional_13(const std::vector<uint8_t>& record, size_t tag_size);
 
 } // namespace fbw
 

--- a/src/TLS/Cryptography/cipher/galois_counter.hpp
+++ b/src/TLS/Cryptography/cipher/galois_counter.hpp
@@ -22,12 +22,12 @@ namespace fbw::aes {
 struct AES_GCM_SHA2_ctx {
     roundkey client_write_round_keys;
     roundkey server_write_round_keys;
-    ustring client_implicit_write_IV;
-    ustring server_implicit_write_IV;
+    std::vector<uint8_t> client_implicit_write_IV;
+    std::vector<uint8_t> server_implicit_write_IV;
     uint64_t seqno_server = 0;
     uint64_t seqno_client = 0;
-    void set_server_key(const ustring& key, size_t key_size, size_t iv_size, const hash_base& hash_ctor);
-    void set_client_key(const ustring& key, size_t key_size, size_t iv_size, const hash_base& hash_ctor);
+    void set_server_key(const std::vector<uint8_t>& key, size_t key_size, size_t iv_size, const hash_base& hash_ctor);
+    void set_client_key(const std::vector<uint8_t>& key, size_t key_size, size_t iv_size, const hash_base& hash_ctor);
 };
 
 class AES_128_GCM_SHA256 : public cipher_base_tls12 {
@@ -37,7 +37,7 @@ class AES_128_GCM_SHA256 : public cipher_base_tls12 {
     AES_GCM_SHA2_ctx ctx;
 public:
     AES_128_GCM_SHA256() = default;
-    void set_key_material_12(ustring material) override;
+    void set_key_material_12(std::vector<uint8_t> material) override;
     tls_record protect(tls_record record) noexcept override;
     tls_record deprotect(tls_record record) override;
 };
@@ -49,8 +49,8 @@ class AES_128_GCM_SHA256_tls13 : public cipher_base_tls13 {
     AES_GCM_SHA2_ctx ctx;
 public:
     AES_128_GCM_SHA256_tls13() = default;
-    void set_server_traffic_key(const ustring& key) override;
-    void set_client_traffic_key(const ustring& key) override;
+    void set_server_traffic_key(const std::vector<uint8_t>& key) override;
+    void set_client_traffic_key(const std::vector<uint8_t>& key) override;
     bool do_key_reset() override;
     tls_record protect(tls_record record) noexcept override;
     tls_record deprotect(tls_record record) override;
@@ -63,8 +63,8 @@ class AES_256_GCM_SHA384 : public cipher_base_tls13 {
     AES_GCM_SHA2_ctx ctx;
 public:
     AES_256_GCM_SHA384() = default;
-    void set_server_traffic_key(const ustring& key) override;
-    void set_client_traffic_key(const ustring& key) override;
+    void set_server_traffic_key(const std::vector<uint8_t>& key) override;
+    void set_client_traffic_key(const std::vector<uint8_t>& key) override;
     bool do_key_reset() override;
     tls_record protect(tls_record record) noexcept override;
     tls_record deprotect(tls_record record) override;

--- a/src/TLS/Cryptography/key_derivation.hpp
+++ b/src/TLS/Cryptography/key_derivation.hpp
@@ -22,37 +22,37 @@ namespace fbw {
 
 struct key_schedule {
 
-    ustring early_secret;
-    ustring resumption_binder_key;
-    ustring external_binder_key;
-    ustring client_early_traffic_secret;
-    ustring early_exporter_master_secret;
-    ustring early_derived_secret;
+    std::vector<uint8_t> early_secret;
+    std::vector<uint8_t> resumption_binder_key;
+    std::vector<uint8_t> external_binder_key;
+    std::vector<uint8_t> client_early_traffic_secret;
+    std::vector<uint8_t> early_exporter_master_secret;
+    std::vector<uint8_t> early_derived_secret;
 
-    ustring handshake_secret;
-    ustring client_handshake_traffic_secret;
-    ustring server_handshake_traffic_secret;
-    ustring handshake_derived_secret;
+    std::vector<uint8_t> handshake_secret;
+    std::vector<uint8_t> client_handshake_traffic_secret;
+    std::vector<uint8_t> server_handshake_traffic_secret;
+    std::vector<uint8_t> handshake_derived_secret;
 
-    ustring master_secret;
-    ustring client_application_traffic_secret;
-    ustring server_application_traffic_secret;
-    ustring exporter_master_secret;
-    ustring resumption_master_secret;
+    std::vector<uint8_t> master_secret;
+    std::vector<uint8_t> client_application_traffic_secret;
+    std::vector<uint8_t> server_application_traffic_secret;
+    std::vector<uint8_t> exporter_master_secret;
+    std::vector<uint8_t> resumption_master_secret;
 };
 
-ustring compute_binder(const hash_base& base, ustring resumption_psk, std::span<const uint8_t> hello_prefix);
-void tls13_early_key_calc(const hash_base& base, key_schedule& key_sch, ustring psk, ustring client_hello_hash);
-void tls13_handshake_key_calc(const hash_base& base, key_schedule& key_sch, ustring ecdh, ustring server_hello_hash);
-void tls13_application_key_calc(const hash_base& base, key_schedule& key_sch, ustring server_finished_hash);
-void tls13_resumption_key_calc(const hash_base& base, key_schedule& key_sch, ustring client_finished_hash);
+std::vector<uint8_t> compute_binder(const hash_base& base, std::vector<uint8_t> resumption_psk, std::span<const uint8_t> hello_prefix);
+void tls13_early_key_calc(const hash_base& base, key_schedule& key_sch, std::vector<uint8_t> psk, std::vector<uint8_t> client_hello_hash);
+void tls13_handshake_key_calc(const hash_base& base, key_schedule& key_sch, std::vector<uint8_t> ecdh, std::vector<uint8_t> server_hello_hash);
+void tls13_application_key_calc(const hash_base& base, key_schedule& key_sch, std::vector<uint8_t> server_finished_hash);
+void tls13_resumption_key_calc(const hash_base& base, key_schedule& key_sch, std::vector<uint8_t> client_finished_hash);
 
 template<typename T>
-ustring P_hash(const hash_base& hash_ctor, const T& secret, const ustring& seed, size_t len) {
-    ustring result;
-    ustring A = do_hmac(hash_ctor, secret, seed);
+std::vector<uint8_t> P_hash(const hash_base& hash_ctor, const T& secret, const std::vector<uint8_t>& seed, size_t len) {
+    std::vector<uint8_t> result;
+    std::vector<uint8_t> A = do_hmac(hash_ctor, secret, seed);
     while (result.size() < len) {
-        ustring A_seed = A;
+        std::vector<uint8_t> A_seed = A;
         A_seed.insert(A_seed.cend(), seed.cbegin(), seed.cend());
         const auto hm = do_hmac(hash_ctor, secret, A_seed);
         result.insert(result.cend(), hm.cbegin(), hm.cend());
@@ -64,15 +64,15 @@ ustring P_hash(const hash_base& hash_ctor, const T& secret, const ustring& seed,
 
 // TLS 1.2 PRF function
 template<typename T, typename U>
-ustring prf(const hash_base& hash_ctor, const T& secret, const std::string& label, const U& seed, size_t len) {
+std::vector<uint8_t> prf(const hash_base& hash_ctor, const T& secret, const std::string& label, const U& seed, size_t len) {
     // Concatenate label and seed
-    ustring label_seed(label.cbegin(), label.cend());
+    std::vector<uint8_t> label_seed(label.cbegin(), label.cend());
     label_seed.insert(label_seed.end(), seed.cbegin(), seed.cend());
     return P_hash(hash_ctor, secret, label_seed, len);
 }
 
 template<typename T, typename U>
-ustring hkdf_expand(const hash_base& hash_ctor, const T& prk, const U& info, size_t length) {
+std::vector<uint8_t> hkdf_expand(const hash_base& hash_ctor, const T& prk, const U& info, size_t length) {
     const size_t hash_len = hash_ctor.get_hash_size();
     const size_t N = (length + hash_len - 1) / hash_len;
 
@@ -80,10 +80,10 @@ ustring hkdf_expand(const hash_base& hash_ctor, const T& prk, const U& info, siz
         assert(false);
     }
 
-    ustring okm;
+    std::vector<uint8_t> okm;
     okm.reserve(length); // check this
 
-    ustring previous_block;
+    std::vector<uint8_t> previous_block;
     for (size_t i = 0; i < N; ++i) {
         auto hmac_ctx = hmac(hash_ctor, prk);
         hmac_ctx.update(previous_block);
@@ -97,10 +97,10 @@ ustring hkdf_expand(const hash_base& hash_ctor, const T& prk, const U& info, siz
 }
 
 template<typename T, typename U>
-ustring hkdf_expand_label(const hash_base& hash_ctor, const T& prk, const std::string& label, const U& context, size_t length) {
+std::vector<uint8_t> hkdf_expand_label(const hash_base& hash_ctor, const T& prk, const std::string& label, const U& context, size_t length) {
     const std::string full_label = "tls13 " + label;
 
-    ustring info(3, 0);
+    std::vector<uint8_t> info(3, 0);
     checked_bigend_write(length, info, 0, 2);
     info[2] =  full_label.size();
     info.insert(info.end(), full_label.begin(), full_label.end());
@@ -112,7 +112,7 @@ ustring hkdf_expand_label(const hash_base& hash_ctor, const T& prk, const std::s
 }
 
 template<typename T, typename U>
-ustring hkdf_extract(const hash_base& hash_ctor, const T& salt, const U& ikm) {
+std::vector<uint8_t> hkdf_extract(const hash_base& hash_ctor, const T& salt, const U& ikm) {
     return do_hmac(hash_ctor, salt, ikm);
 }
 

--- a/src/TLS/Cryptography/one_way/hash_base.hpp
+++ b/src/TLS/Cryptography/one_way/hash_base.hpp
@@ -31,14 +31,14 @@ public:
         return update_impl(data.data(), data.size());
     }
      
-    [[nodiscard]] virtual ustring hash() const = 0;
+    [[nodiscard]] virtual std::vector<uint8_t> hash() const = 0;
 
     [[nodiscard]] virtual size_t get_block_size() const noexcept = 0;
     [[nodiscard]] virtual size_t get_hash_size() const noexcept = 0;
 };
 
 template<typename T> 
-ustring do_hash(const hash_base& hash_ctor, const T& data) {
+std::vector<uint8_t> do_hash(const hash_base& hash_ctor, const T& data) {
     auto ctx = hash_ctor.clone();
     ctx->update(data);
     return ctx->hash();

--- a/src/TLS/Cryptography/one_way/hmac.cpp
+++ b/src/TLS/Cryptography/one_way/hmac.cpp
@@ -30,7 +30,7 @@ size_t hmac::get_hash_size() const noexcept {
     return m_hasher->get_block_size();
 }
 
-ustring hmac::hash() const {
+std::vector<uint8_t> hmac::hash() const {
     std::vector<uint8_t> opadkey;
     opadkey.resize(m_factory->get_block_size());
     std::transform(KeyPrime.cbegin(), KeyPrime.cend(), opadkey.begin(), [](uint8_t c){return c ^ 0x5c;});
@@ -41,7 +41,7 @@ ustring hmac::hash() const {
     outsha->update(opadkey);
     outsha->update(hsh);
     auto outarr = outsha->hash();
-    ustring outvec;
+    std::vector<uint8_t> outvec;
     outvec.insert(outvec.cend(), outarr.cbegin(), outarr.cend());
     return outvec;
 }
@@ -82,7 +82,7 @@ hmac::hmac(const hash_base& hasher, const uint8_t* key, size_t key_len) {
         std::copy_n(key, key_len, KeyPrime.begin());
     }
     assert(KeyPrime.size() == hasher.get_block_size());
-    ustring ipadkey;
+    std::vector<uint8_t> ipadkey;
     ipadkey.resize(m_factory->get_block_size());
     assert(ipadkey.size() == hasher.get_block_size());
     std::transform(KeyPrime.cbegin(), KeyPrime.cend(), ipadkey.begin(), [](uint8_t c){return c ^ 0x36;});

--- a/src/TLS/Cryptography/one_way/hmac.cpp
+++ b/src/TLS/Cryptography/one_way/hmac.cpp
@@ -42,7 +42,7 @@ ustring hmac::hash() const {
     outsha->update(hsh);
     auto outarr = outsha->hash();
     ustring outvec;
-    outvec.append(outarr.cbegin(), outarr.cend());
+    outvec.insert(outvec.cend(), outarr.cbegin(), outarr.cend());
     return outvec;
 }
 

--- a/src/TLS/Cryptography/one_way/hmac.hpp
+++ b/src/TLS/Cryptography/one_way/hmac.hpp
@@ -29,7 +29,7 @@ public:
     template<typename T> hmac(const hash_base& hasher, const T& key);
     std::unique_ptr<hash_base> clone() const override;
     hmac& update_impl(const uint8_t* key, size_t key_len) noexcept override;
-    [[nodiscard]] ustring hash() const override;
+    [[nodiscard]] std::vector<uint8_t> hash() const override;
     using hash_base::hash;
     [[nodiscard]] size_t get_block_size() const noexcept override;
     [[nodiscard]] size_t get_hash_size() const noexcept override;
@@ -46,7 +46,7 @@ hmac::hmac(const hash_base& hasher, const T& key) :
 
 
 template<typename T, typename U>
-ustring do_hmac(const hash_base& hash_ctor, const T& key, const U& data) {
+std::vector<uint8_t> do_hmac(const hash_base& hash_ctor, const T& key, const U& data) {
     auto mac = hmac(hash_ctor, key);
     mac.update(data);
     return mac.hash();

--- a/src/TLS/Cryptography/one_way/sha1.cpp
+++ b/src/TLS/Cryptography/one_way/sha1.cpp
@@ -99,7 +99,7 @@ sha1& sha1::update_impl(const uint8_t* const data, size_t size) noexcept {
     return *this;
 }
 
-ustring sha1::hash() const {
+std::vector<uint8_t> sha1::hash() const {
     auto o_data = m_data;
     auto o_state = m_state;
 
@@ -110,7 +110,7 @@ ustring sha1::hash() const {
     }
     checked_bigend_write(datalen * 8, o_data, 56, 8);
     sha1_transform(o_state, o_data);
-    ustring hash;
+    std::vector<uint8_t> hash;
     hash.resize(20);
     for(int i = 0; i < 5; i ++) {
         checked_bigend_write(o_state[i], hash, i*4, 4);

--- a/src/TLS/Cryptography/one_way/sha1.hpp
+++ b/src/TLS/Cryptography/one_way/sha1.hpp
@@ -29,7 +29,7 @@ public:
     std::unique_ptr<hash_base> clone() const override;
     sha1& update_impl(const uint8_t* begin, size_t size) noexcept override;
     
-    ustring hash() const override;
+    std::vector<uint8_t> hash() const override;
     [[nodiscard]] size_t get_block_size() const noexcept override;
     [[nodiscard]] size_t get_hash_size() const noexcept override;
 

--- a/src/TLS/Cryptography/one_way/sha2.cpp
+++ b/src/TLS/Cryptography/one_way/sha2.cpp
@@ -136,9 +136,9 @@ void sha2_transform(std::array<RADIX, 8 >& state, const std::array<uint8_t, BLOC
 }
 
 template<typename RADIX, size_t BLOCK_SIZE, size_t HASH_SIZE, size_t COUNTER_SIZE, size_t INTERNAL_STATE_SIZE>
-ustring hash_impl(std::array<uint8_t, BLOCK_SIZE> data, std::array<RADIX, 8> state, uint64_t bitlen, size_t datalen) {
+std::vector<uint8_t> hash_impl(std::array<uint8_t, BLOCK_SIZE> data, std::array<RADIX, 8> state, uint64_t bitlen, size_t datalen) {
     bitlen += datalen * CHAR_BIT;
-    ustring hash;
+    std::vector<uint8_t> hash;
     hash.resize(HASH_SIZE);
     data[datalen] = 0x80;
     datalen++;
@@ -254,11 +254,11 @@ sha256::sha256() noexcept  : datalen(0),  bitlen(0), m_data() {
     state = state0;
 }
 
-ustring sha384::hash() const {
+std::vector<uint8_t> sha384::hash() const {
     return hash_impl<uint64_t, 128, 48, 16, 80>(m_data, state, bitlen, datalen);
 }
 
-ustring sha256::hash() const {
+std::vector<uint8_t> sha256::hash() const {
     return hash_impl<uint32_t, 64, 32, 8, 64>(m_data, state, bitlen, datalen);
 }
 

--- a/src/TLS/Cryptography/one_way/sha2.hpp
+++ b/src/TLS/Cryptography/one_way/sha2.hpp
@@ -28,7 +28,7 @@ public:
     std::unique_ptr<hash_base> clone() const override;
     sha256& update_impl(const uint8_t* begin, size_t size) noexcept override;
     
-    ustring hash() const override;
+    std::vector<uint8_t> hash() const override;
     [[nodiscard]] size_t get_block_size() const noexcept override;
     [[nodiscard]] size_t get_hash_size() const noexcept override;
 private:
@@ -47,7 +47,7 @@ public:
     std::unique_ptr<hash_base> clone() const override;
     sha384& update_impl(const uint8_t* begin, size_t size) noexcept override;
     
-    ustring hash() const override;
+    std::vector<uint8_t> hash() const override;
     [[nodiscard]] size_t get_block_size() const noexcept override;
     [[nodiscard]] size_t get_hash_size() const noexcept override;
 private:

--- a/src/TLS/PEMextract.cpp
+++ b/src/TLS/PEMextract.cpp
@@ -53,7 +53,7 @@ ustring decode64(std::string data) {
         j += 6;
         if(j >= 8) {
             j -= 8;
-            out.append({static_cast<uint8_t>(buffer >> j)});
+            out.insert(out.end(), {static_cast<uint8_t>(buffer >> j)});
         }
     }
     return out;
@@ -66,7 +66,8 @@ std::array<uint8_t,32> deserialise(ustring asn1) {
     const ustring eckey_id = { 0x06, 0x07, 0x2A, 0x86, 0x48, 0xCE, 0x3D, 0x02, 0x01};
     const ustring secp256k1_id = { 0x06, 0x08, 0x2A, 0x86, 0x48, 0xCE, 0x3D, 0x03, 0x01, 0x07};
 
-    if (eckey_id != asn1.substr(8, 9) or secp256k1_id != asn1.substr(17, 10)) {
+    if (!std::equal(eckey_id.begin(), eckey_id.end(), asn1.begin() + 8) ||
+        !std::equal(secp256k1_id.begin(), secp256k1_id.end(), asn1.begin() + 17)) {
         throw ssl_error("unsupported certificate private key format", AlertLevel::fatal, AlertDescription::handshake_failure);
     }
 

--- a/src/TLS/PEMextract.hpp
+++ b/src/TLS/PEMextract.hpp
@@ -19,11 +19,11 @@ namespace fbw {
 
 std::array<unsigned char,32> privkey_from_file(std::filesystem::path filename);
 
-std::vector<ustring> der_cert_from_file(std::filesystem::path filename);
+std::vector<std::vector<uint8_t>> der_cert_from_file(std::filesystem::path filename);
 
 std::array<uint8_t,32> privkey_for_domain(std::string domain);
 
-std::vector<ustring> der_cert_for_domain(std::string domain);
+std::vector<std::vector<uint8_t>> der_cert_for_domain(std::string domain);
 } //namespace fbw
 
 

--- a/src/TLS/TLS_enums.hpp
+++ b/src/TLS/TLS_enums.hpp
@@ -109,7 +109,7 @@ enum class CertChainType : uint8_t {
     pkipath = 1
 };
 struct URLAndHash{
-    ustring url;
+    std::vector<uint8_t> url;
     // uint8_t padding;
     std::array<uint8_t, 20> SHA1Hash;
 };
@@ -160,8 +160,8 @@ enum class IdentifierType : uint8_t {
 };
 
 struct OCSPStatusRequest {
-    std::vector<ustring> responderID;
-    ustring extensions;
+    std::vector<std::vector<uint8_t>> responderID;
+    std::vector<uint8_t> extensions;
 };
 
 enum class CertificateStatusType : uint8_t {
@@ -175,7 +175,7 @@ struct CertificateStatusRequest {
 
 struct CertificateStatus {
     CertificateStatusType status_type;
-    ustring response;
+    std::vector<uint8_t> response;
 };
 
 enum class AlertDescription : uint8_t {

--- a/src/TLS/TLS_utils.cpp
+++ b/src/TLS/TLS_utils.cpp
@@ -16,7 +16,7 @@ namespace fbw {
 
 void certificates_serial(tls_record& record, std::string domain, bool tls_13) {
     record.start_size_header(3);
-    std::vector<ustring> certs;
+    std::vector<std::vector<uint8_t>> certs;
     try {
         certs = der_cert_for_domain(domain);
     } catch(std::exception& e) {

--- a/src/TLS/TLS_utils.cpp
+++ b/src/TLS/TLS_utils.cpp
@@ -35,7 +35,7 @@ void certificates_serial(tls_record& record, std::string domain, bool tls_13) {
     record.end_size_header();
 }
 
-std::optional<tls_record> try_extract_record(ustring& input) {
+std::optional<tls_record> try_extract_record(std::vector<uint8_t>& input) {
     if (input.size() < TLS_HEADER_SIZE) {
         return std::nullopt;
     }
@@ -48,8 +48,8 @@ std::optional<tls_record> try_extract_record(ustring& input) {
     if(input.size() < record_size + TLS_HEADER_SIZE) [[unlikely]] {
         return std::nullopt;
     }
-    out.m_contents = input.substr(TLS_HEADER_SIZE, record_size);
-    input = input.substr(TLS_HEADER_SIZE + record_size);
+    out.m_contents.assign(input.begin() + TLS_HEADER_SIZE, input.begin() + TLS_HEADER_SIZE + record_size);
+    input.erase(input.begin(), input.begin() + TLS_HEADER_SIZE + record_size);
     return out;
 }
 

--- a/src/TLS/TLS_utils.hpp
+++ b/src/TLS/TLS_utils.hpp
@@ -35,7 +35,7 @@ private:
     };
     std::vector<der_headers> heads;
 public:
-    ustring m_contents;
+    std::vector<uint8_t> m_contents;
     
     inline ContentType get_type() const { return static_cast<ContentType>(m_type); }
     inline uint8_t get_major_version() const { return m_major_version; }
@@ -71,7 +71,7 @@ public:
     void write(const T& value) {
         m_contents.insert(m_contents.cend(), value.cbegin(), value.cend());
     }
-    inline void write(const ustring& value) {
+    inline void write(const std::vector<uint8_t>& value) {
         m_contents.insert(m_contents.cend(), value.cbegin(), value.cend());
     }
 
@@ -79,7 +79,7 @@ public:
     // append data and then figure out the header size
     inline void start_size_header(ssize_t bytes) {
         heads.push_back({static_cast<ssize_t>(m_contents.size()), bytes});
-        auto size = ustring(bytes, 0);
+        auto size = std::vector<uint8_t>(bytes, 0);
         m_contents.insert(m_contents.cend(), size.cbegin(), size.cend());
     }
 
@@ -89,9 +89,9 @@ public:
         checked_bigend_write(m_contents.size() - idx_start - num_bytes, m_contents, idx_start, num_bytes);
     }
     
-    inline ustring serialise() const {
+    inline std::vector<uint8_t> serialise() const {
         assert(m_contents.size() != 0);
-        ustring out;
+        std::vector<uint8_t> out;
         out.insert(out.end(), {static_cast<uint8_t>(m_type), m_major_version, m_minor_version, 0,0});
         checked_bigend_write(m_contents.size(), out, 3, 2);
         out.insert(out.end(), m_contents.cbegin(), m_contents.cend());
@@ -100,7 +100,7 @@ public:
 };
 
 void certificates_serial(tls_record& record, std::string domain, bool use_tls13);
-std::optional<tls_record> try_extract_record(ustring& input);
+std::optional<tls_record> try_extract_record(std::vector<uint8_t>& input);
 
 } // namespace
 

--- a/src/TLS/TLS_utils.hpp
+++ b/src/TLS/TLS_utils.hpp
@@ -58,21 +58,21 @@ public:
 
     template<typename T>
     inline void write2(T value) {
-        m_contents.append({ 0, 0 });
+        m_contents.insert(m_contents.cend(), { 0, 0 });
         checked_bigend_write(static_cast<uint16_t>(value), m_contents, m_contents.size() - 2, 2);
     }
 
     inline void write2(uint16_t value) {
-        m_contents.append({ 0, 0 });
+        m_contents.insert(m_contents.cend(), { 0, 0 });
         checked_bigend_write(value, m_contents, m_contents.size() - 2, 2);
     }
 
     template<typename T>
     void write(const T& value) {
-        m_contents.append(value.begin(), value.end());
+        m_contents.insert(m_contents.cend(), value.cbegin(), value.cend());
     }
     inline void write(const ustring& value) {
-        m_contents.append(value);
+        m_contents.insert(m_contents.cend(), value.cbegin(), value.cend());
     }
 
     // record items with variable length include a header and are sometimes nested
@@ -80,7 +80,7 @@ public:
     inline void start_size_header(ssize_t bytes) {
         heads.push_back({static_cast<ssize_t>(m_contents.size()), bytes});
         auto size = ustring(bytes, 0);
-        m_contents.append(size);
+        m_contents.insert(m_contents.cend(), size.cbegin(), size.cend());
     }
 
     inline void end_size_header() {
@@ -92,9 +92,9 @@ public:
     inline ustring serialise() const {
         assert(m_contents.size() != 0);
         ustring out;
-        out.append({static_cast<uint8_t>(m_type), m_major_version, m_minor_version, 0,0});
+        out.insert(out.end(), {static_cast<uint8_t>(m_type), m_major_version, m_minor_version, 0,0});
         checked_bigend_write(m_contents.size(), out, 3, 2);
-        out.append(m_contents);
+        out.insert(out.end(), m_contents.cbegin(), m_contents.cend());
         return out;
     }
 };

--- a/src/TLS/handshake.cpp
+++ b/src/TLS/handshake.cpp
@@ -148,7 +148,7 @@ std::string choose_alpn(const std::vector<std::string>& client_alpn) {
     }
     if(std::find(client_alpn.begin(), client_alpn.end(), "h2") != client_alpn.end()) {
         // todo: toggle
-        // return "h2";
+        //return "h2";
     }
     if(std::find(client_alpn.begin(), client_alpn.end(), "http/1.1") == client_alpn.end()) {
         throw ssl_error("no supported application layer protocols", AlertLevel::fatal, AlertDescription::no_application_protocol);

--- a/src/TLS/handshake.cpp
+++ b/src/TLS/handshake.cpp
@@ -143,17 +143,24 @@ void handshake_ctx::set_cipher_ctx(cipher_suites cipher_suite) {
 }
 
 std::string choose_alpn(const std::vector<std::string>& client_alpn) {
+    constexpr const char* ALPN_H1 = "http/1.1";
+    constexpr const char* ALPN_H2 = "h2";
     if(client_alpn.empty()) {
-        return "http/1.1";
+        return ALPN_H1;
     }
-    if(std::find(client_alpn.begin(), client_alpn.end(), "h2") != client_alpn.end()) {
-        // todo: toggle
-        //return "h2";
+    // toggle
+    if(std::find(client_alpn.begin(), client_alpn.end(), ALPN_H1) != client_alpn.end()) {
+        // comment out to prioritise H2
+        return ALPN_H1;
     }
-    if(std::find(client_alpn.begin(), client_alpn.end(), "http/1.1") == client_alpn.end()) {
-        throw ssl_error("no supported application layer protocols", AlertLevel::fatal, AlertDescription::no_application_protocol);
+    if(std::find(client_alpn.begin(), client_alpn.end(), ALPN_H2) != client_alpn.end()) {
+        // comment out to disable H2
+        return ALPN_H2;
     }
-    return "http/1.1";
+    if(std::find(client_alpn.begin(), client_alpn.end(), ALPN_H1) != client_alpn.end()) {
+        return ALPN_H1;
+    }
+    throw ssl_error("no supported application layer protocols", AlertLevel::fatal, AlertDescription::no_application_protocol);
 }
 
 std::string choose_server_name(const std::vector<std::string>& server_names) {

--- a/src/TLS/handshake.cpp
+++ b/src/TLS/handshake.cpp
@@ -214,7 +214,7 @@ key_share choose_client_public_key(const std::vector<key_share>& keys, const std
     throw ssl_error("named group mismatch", AlertLevel::fatal, AlertDescription::handshake_failure);
 }
 
-tls_record synthetic_message_hash(const hash_base& hash_ctor, const ustring& client_hello) {
+tls_record synthetic_message_hash(const hash_base& hash_ctor, const std::vector<uint8_t>& client_hello) {
     tls_record record(ContentType::Handshake);
     record.write1(HandshakeType::message_hash);
     record.start_size_header(3);
@@ -225,10 +225,10 @@ tls_record synthetic_message_hash(const hash_base& hash_ctor, const ustring& cli
     return record;
 }
 
-std::tuple<ustring, std::optional<size_t>, bool> handshake_ctx::get_resumption_psk(const ustring& prefix_hash) const {
+std::tuple<std::vector<uint8_t>, std::optional<size_t>, bool> handshake_ctx::get_resumption_psk(const std::vector<uint8_t>& prefix_hash) const {
     auto key = client_hello.pre_shared_key;
     assert(hash_ctor != nullptr);
-    auto null_psk = ustring(hash_ctor->get_hash_size(), 0);
+    auto null_psk = std::vector<uint8_t>(hash_ctor->get_hash_size(), 0);
     if(!key) {
         return {null_psk, std::nullopt, false};
     }
@@ -274,7 +274,7 @@ std::tuple<ustring, std::optional<size_t>, bool> handshake_ctx::get_resumption_p
             break;
         }
         auto received_binder = client_hello.pre_shared_key->m_psk_binder_entries[i];
-        ustring computed_binder = compute_binder(*hash_ctor, ticket->resumption_secret, prefix_hash);
+        std::vector<uint8_t> computed_binder = compute_binder(*hash_ctor, ticket->resumption_secret, prefix_hash);
         if(received_binder != computed_binder ) {
             continue;
         }
@@ -290,7 +290,7 @@ std::tuple<ustring, std::optional<size_t>, bool> handshake_ctx::get_resumption_p
     return {null_psk, std::nullopt, false};
 }
 
-void handshake_ctx::client_hello_record(const ustring& handshake_message) {
+void handshake_ctx::client_hello_record(const std::vector<uint8_t>& handshake_message) {
     client_hello = parse_client_hello(handshake_message);
     if(server_hello_type != ServerHelloType::hello_retry) {
         auto cipher_id = choose_cipher(client_hello);
@@ -302,7 +302,7 @@ void handshake_ctx::client_hello_record(const ustring& handshake_message) {
 
     alpn = choose_alpn(client_hello.application_layer_protocols);
     
-    ustring psk = ustring(hash_ctor->get_hash_size(), 0);
+    std::vector<uint8_t> psk = std::vector<uint8_t>(hash_ctor->get_hash_size(), 0);
     if(*p_tls_version == TLS13) {
         if(!client_hello.parsed_extensions.contains(ExtensionType::supported_groups)) {
             throw ssl_error("supported groups are required for TLS 1.3", AlertLevel::fatal, AlertDescription::illegal_parameter);
@@ -428,9 +428,9 @@ tls_record handshake_ctx::server_hello_record() {
     handshake_hasher->update(hello_record.m_contents);
 
     if(*p_tls_version == TLS13 and server_hello_type != ServerHelloType::hello_retry) {
-        ustring shared_secret;
+        std::vector<uint8_t> shared_secret;
         if(server_hello_type == ServerHelloType::preshared_key) {
-            shared_secret = ustring();
+            shared_secret = std::vector<uint8_t>();
         } else {
             shared_secret = get_shared_secret(server_private_key_ephem, client_public_key);
         }
@@ -475,9 +475,9 @@ tls_record handshake_ctx::server_certificate_record() {
     auto hash_verify_context = handshake_hasher->hash();
 
     sha256 ctx;
-    ctx.update(ustring(64, 0x20));
+    ctx.update(std::vector<uint8_t>(64, 0x20));
     ctx.update(to_unsigned("TLS 1.3, server CertificateVerify"));
-    ctx.update(ustring{0});
+    ctx.update(std::vector<uint8_t>{0});
     ctx.update(hash_verify_context);
     auto hash_out = ctx.hash();
 
@@ -485,7 +485,7 @@ tls_record handshake_ctx::server_certificate_record() {
     std::copy(hash_out.begin(), hash_out.end(), signature_digest.begin());
     std::array<uint8_t, 32> csrn;
     randomgen.randgen(csrn);
-    ustring signature = secp256r1::DER_ECDSA(std::move(csrn), std::move(signature_digest), std::move(certificate_private));
+    std::vector<uint8_t> signature = secp256r1::DER_ECDSA(std::move(csrn), std::move(signature_digest), std::move(certificate_private));
 
     tls_record record(ContentType::Handshake);
     record.write1(HandshakeType::certificate_verify);
@@ -515,11 +515,11 @@ tls_record handshake_ctx::server_handshake_finished13_record() {
     return record;
 }
 
-void handshake_ctx::client_end_of_early_data_record(const ustring& handshake_message) {
+void handshake_ctx::client_end_of_early_data_record(const std::vector<uint8_t>& handshake_message) {
     handshake_hasher->update(handshake_message);
 }
 
-void handshake_ctx::client_handshake_finished13_record(const ustring& handshake_message) {
+void handshake_ctx::client_handshake_finished13_record(const std::vector<uint8_t>& handshake_message) {
     auto server_finished_hash = handshake_hasher->hash();
     auto client_finished_key = hkdf_expand_label(*hash_ctor, tls13_key_schedule.client_handshake_traffic_secret, "finished", std::string(""), hash_ctor->get_hash_size());
     auto verify_data = do_hmac(*hash_ctor, client_finished_key, server_finished_hash);
@@ -550,7 +550,7 @@ tls_record handshake_ctx::server_key_exchange_record() {
     checked_bigend_write(static_cast<size_t>(NamedGroup::x25519), curve_info, 1, 2);
     
     // Public Key
-    ustring signed_empheral_key;
+    std::vector<uint8_t> signed_empheral_key;
     signed_empheral_key.insert(signed_empheral_key.end(), curve_info.cbegin(), curve_info.cend());
     signed_empheral_key.insert(signed_empheral_key.end(), {static_cast<uint8_t>(pubkey_ephem.size())});
     signed_empheral_key.insert(signed_empheral_key.end(), pubkey_ephem.cbegin(), pubkey_ephem.cend());
@@ -572,8 +572,8 @@ tls_record handshake_ctx::server_key_exchange_record() {
     // Signature
     std::array<uint8_t, 32> csrn;
     randomgen.randgen(csrn);
-    ustring signature = secp256r1::DER_ECDSA(std::move(csrn), std::move(signature_digest), std::move(certificate_private));
-    ustring sig_header ({static_cast<uint8_t>(HashAlgorithm::sha256), // Signature Header
+    std::vector<uint8_t> signature = secp256r1::DER_ECDSA(std::move(csrn), std::move(signature_digest), std::move(certificate_private));
+    std::vector<uint8_t> sig_header ({static_cast<uint8_t>(HashAlgorithm::sha256), // Signature Header
         static_cast<uint8_t>(SignatureAlgorithm::ecdsa)});
     
     record.write(signed_empheral_key);
@@ -607,7 +607,7 @@ tls_record handshake_ctx::server_handshake_finished12_record() {
     auto handshake_hash = handshake_hasher->hash();
     assert(handshake_hash.size() == 32);
     
-    ustring server_finished = prf(*hash_ctor, tls12_master_secret, "server finished", handshake_hash, 12);
+    std::vector<uint8_t> server_finished = prf(*hash_ctor, tls12_master_secret, "server finished", handshake_hash, 12);
     
     out.write(server_finished);
     out.end_size_header();
@@ -660,7 +660,7 @@ void handshake_ctx::hello_extensions(tls_record& record) {
 }
 
 
-ustring handshake_ctx::client_key_exchange_receipt(const ustring& key_exchange) {
+std::vector<uint8_t> handshake_ctx::client_key_exchange_receipt(const std::vector<uint8_t>& key_exchange) {
     
     static_cast<void>(key_exchange.at(0));
     assert(key_exchange[0] == static_cast<uint8_t>(HandshakeType::client_key_exchange));
@@ -680,14 +680,14 @@ ustring handshake_ctx::client_key_exchange_receipt(const ustring& key_exchange) 
     std::array<uint8_t, 32> client_pub{};
     std::copy_n(client_public_key.key.begin(), 32, client_pub.begin());
     auto premaster_secret = fbw::curve25519::multiply(server_private_key_ephem, client_pub);
-    ustring combined_random(client_hello.m_client_random.begin(), client_hello.m_client_random.end());
+    std::vector<uint8_t> combined_random(client_hello.m_client_random.begin(), client_hello.m_client_random.end());
     combined_random.insert(combined_random.end(), m_server_random.begin(), m_server_random.end());
     tls12_master_secret = prf(*hash_ctor, premaster_secret, "master secret", combined_random, 48);
 
     assert(handshake_hasher);
     handshake_hasher->update(key_exchange);
 
-    ustring combined_random_flipped(m_server_random.begin(), m_server_random.end());
+    std::vector<uint8_t> combined_random_flipped(m_server_random.begin(), m_server_random.end());
     combined_random_flipped.insert(combined_random_flipped.end(), client_hello.m_client_random.begin(), client_hello.m_client_random.end());
 
     // AES_256_CBC_SHA256 has the largest amount of key material at 128 bytes
@@ -695,7 +695,7 @@ ustring handshake_ctx::client_key_exchange_receipt(const ustring& key_exchange) 
     return key_material;
 }
 
-void handshake_ctx::client_handshake_finished12_record(const ustring& handshake_message) {
+void handshake_ctx::client_handshake_finished12_record(const std::vector<uint8_t>& handshake_message) {
     
     static_cast<void>(handshake_message.at(0));
     if(handshake_message[0] != static_cast<uint8_t>(HandshakeType::finished)) [[unlikely]] {
@@ -716,7 +716,7 @@ void handshake_ctx::client_handshake_finished12_record(const ustring& handshake_
     }
 
     auto handshake_hash = handshake_hasher->hash();
-    ustring expected_finished = prf(*hash_ctor, tls12_master_secret, "client finished", handshake_hash, 12);
+    std::vector<uint8_t> expected_finished = prf(*hash_ctor, tls12_master_secret, "client finished", handshake_hash, 12);
 
     if (!std::equal(expected_finished.begin(), expected_finished.end(), handshake_message.begin() + 4)) [[unlikely]] {
         throw ssl_error("handshake verification failed", AlertLevel::fatal, AlertDescription::handshake_failure);

--- a/src/TLS/handshake.cpp
+++ b/src/TLS/handshake.cpp
@@ -151,7 +151,7 @@ std::string choose_alpn(const std::vector<std::string>& client_alpn) {
     // toggle
     if(std::find(client_alpn.begin(), client_alpn.end(), ALPN_H1) != client_alpn.end()) {
         // comment out to prioritise H2
-        return ALPN_H1;
+        //return ALPN_H1;
     }
     if(std::find(client_alpn.begin(), client_alpn.end(), ALPN_H2) != client_alpn.end()) {
         // comment out to disable H2

--- a/src/TLS/handshake.cpp
+++ b/src/TLS/handshake.cpp
@@ -151,7 +151,7 @@ std::string choose_alpn(const std::vector<std::string>& client_alpn) {
     // toggle
     if(std::find(client_alpn.begin(), client_alpn.end(), ALPN_H1) != client_alpn.end()) {
         // comment out to prioritise H2
-        //return ALPN_H1;
+        return ALPN_H1;
     }
     if(std::find(client_alpn.begin(), client_alpn.end(), ALPN_H2) != client_alpn.end()) {
         // comment out to disable H2

--- a/src/TLS/handshake.hpp
+++ b/src/TLS/handshake.hpp
@@ -44,14 +44,14 @@ class handshake_ctx {
 public:
     key_share client_public_key {};
     std::unique_ptr<hash_base> handshake_hasher = nullptr;
-    ustring m_server_random {};
+    std::vector<uint8_t> m_server_random {};
     
     std::unique_ptr<const hash_base> hash_ctor = nullptr;
     std::array<uint8_t,32> server_private_key_ephem {};
     
     hello_record_data client_hello;
     key_schedule tls13_key_schedule;
-    ustring tls12_master_secret;
+    std::vector<uint8_t> tls12_master_secret;
 
     std::string alpn;
 
@@ -77,13 +77,13 @@ public:
     tls_record server_encrypted_extensions_record();
     tls_record server_hello_done_record();
 
-    void client_end_of_early_data_record(const ustring& handshake_message);
+    void client_end_of_early_data_record(const std::vector<uint8_t>& handshake_message);
 
-    void client_hello_record(const ustring& handshake_message);
-    ustring client_key_exchange_receipt(const ustring& handshake_message);
+    void client_hello_record(const std::vector<uint8_t>& handshake_message);
+    std::vector<uint8_t> client_key_exchange_receipt(const std::vector<uint8_t>& handshake_message);
 
-    void client_handshake_finished12_record(const ustring& handshake_message);
-    void client_handshake_finished13_record(const ustring& handshake_message);
+    void client_handshake_finished12_record(const std::vector<uint8_t>& handshake_message);
+    void client_handshake_finished13_record(const std::vector<uint8_t>& handshake_message);
 
     tls_record server_handshake_finished12_record();
     tls_record server_handshake_finished13_record();
@@ -94,7 +94,7 @@ private:
 
     void set_cipher_ctx(cipher_suites cipher_suite);
 
-    std::tuple<ustring, std::optional<size_t>, bool> get_resumption_psk(const ustring& hello_message) const;
+    std::tuple<std::vector<uint8_t>, std::optional<size_t>, bool> get_resumption_psk(const std::vector<uint8_t>& hello_message) const;
     
 };
 

--- a/src/TLS/hello.cpp
+++ b/src/TLS/hello.cpp
@@ -249,7 +249,7 @@ hello_record_data parse_client_hello(const ustring& hello) {
     // session ID
     size_t idx = 38;
     auto session_id_span = der_span_read(hello, idx, 1);
-    record.client_session_id.append(session_id_span.begin(), session_id_span.end());
+    record.client_session_id.insert(record.client_session_id.end(), session_id_span.begin(), session_id_span.end());
     idx += (session_id_span.size() + 1);
 
     // cipher suites

--- a/src/TLS/hello.hpp
+++ b/src/TLS/hello.hpp
@@ -11,16 +11,16 @@ namespace fbw {
 
 struct extension {
     ExtensionType type;
-    ustring data;
+    std::vector<uint8_t> data;
 };
 
 struct key_share {
     NamedGroup key_type;
-    ustring key;
+    std::vector<uint8_t> key;
 };
 
 struct pre_shared_key_entry {
-    ustring m_key;
+    std::vector<uint8_t> m_key;
     uint32_t m_obfuscated_age;
 };
 
@@ -28,7 +28,7 @@ struct preshared_key_ext {
     std::ptrdiff_t idxbinders_ext = 0;
     std::ptrdiff_t idxbinders = 0;
     std::vector<pre_shared_key_entry> m_keys;
-    std::vector<ustring> m_psk_binder_entries;
+    std::vector<std::vector<uint8_t>> m_psk_binder_entries;
 };
 
 struct hello_record_data {
@@ -36,7 +36,7 @@ struct hello_record_data {
 
     uint16_t legacy_client_version = 0;
     std::array<uint8_t, 32> m_client_random {};
-    ustring client_session_id {};
+    std::vector<uint8_t> client_session_id {};
     std::vector<cipher_suites> cipher_su{};
     std::vector<uint8_t> compression_types{};
 
@@ -64,7 +64,7 @@ struct hello_record_data {
     bool truncated_hmac = false;
 };
 
-hello_record_data parse_client_hello(const ustring& hello_contents);
+hello_record_data parse_client_hello(const std::vector<uint8_t>& hello_contents);
 
 // server hello extensions
 void write_alpn_extension(tls_record& record, std::string alpn);
@@ -77,9 +77,9 @@ void write_cookie(tls_record& record);
 void write_pre_shared_key_extension(tls_record& record, uint16_t key_id);
 void write_early_data_encrypted_ext(tls_record& record);
 
-ustring get_shared_secret(std::array<uint8_t, 32> server_private_key_ephem, key_share peer_key);
+std::vector<uint8_t> get_shared_secret(std::array<uint8_t, 32> server_private_key_ephem, key_share peer_key);
 std::pair<std::array<uint8_t, 32>, key_share> server_keypair(const NamedGroup& client_keytype);
-ustring make_hello_random(uint16_t version, bool requires_hello_retry);
+std::vector<uint8_t> make_hello_random(uint16_t version, bool requires_hello_retry);
 
 }
 

--- a/src/TLS/protocol.cpp
+++ b/src/TLS/protocol.cpp
@@ -176,4 +176,19 @@ task<void> TLS::close_notify() {
     } while(false);
 }
 
+std::deque<uint8_t> buffer::write(const std::span<const uint8_t> data) {
+    m_buffer.insert(m_buffer.end(), data.begin(), data.end());
+    if(m_buffer.size() >= BUFFER_SIZE) {
+        std::deque<uint8_t> out;
+        out.assign(m_buffer.begin(), m_buffer.begin() + BUFFER_SIZE);
+        m_buffer.erase(m_buffer.begin(), m_buffer.begin() + BUFFER_SIZE);
+        return out;
+    }
+    return {};
+}
+
+std::deque<uint8_t> buffer::flush() {
+    return std::exchange(m_buffer, {});
+}
+    
 }// namespace fbw

--- a/src/TLS/protocol.cpp
+++ b/src/TLS/protocol.cpp
@@ -42,7 +42,7 @@ task<stream_result> TLS::read_append_common(ustring& data, std::optional<millise
     co_await m_async_read_mut.lock();
     auto initial_size = data.size();
     if(!early_data_buffer.empty()) {
-        data.append(std::move(early_data_buffer));
+        data.insert(data.end(), early_data_buffer.begin(), early_data_buffer.end());
         early_data_buffer.clear();
     }
     for(;;) {

--- a/src/TLS/protocol.cpp
+++ b/src/TLS/protocol.cpp
@@ -60,13 +60,7 @@ task<stream_result> TLS::read_append_common(ustring& data, std::optional<millise
         if(m_engine.m_expected_read_record > HandshakeStage::client_early_data and return_early) {
             read_timeout = timeout;
         }
-        if(alpn() == "h2") {
-            std::cout << "TCP read" << std::endl;
-        }
         auto read_res = co_await m_client->read_append(input_data, read_timeout);
-        if(alpn() == "h2") {
-            std::cout << "TCP read done" << std::endl;
-        }
         if(read_res != stream_result::ok) {
             co_return read_res;
         }
@@ -124,7 +118,6 @@ std::string TLS::alpn() {
 // application code calls this to send data to the client
 task<stream_result> TLS::write(ustring data, std::optional<milliseconds> timeout) {
     m_engine.process_net_write(output, data, timeout);
-    m_engine.process_net_flush(output); // remove this
     co_return co_await net_write_all();
 }
 
@@ -150,12 +143,6 @@ task<stream_result> TLS::net_write_all() {
         }
     }
     co_return stream_result::ok;
-}
-
-// application data is sent on a buffered stream so the pattern of record sizes reveals much less
-task<stream_result> TLS::flush() {
-    m_engine.process_net_flush(output);
-    co_return co_await net_write_all();
 }
 
 // applications call this when graceful not abrupt closing of a connection is desired

--- a/src/TLS/protocol.cpp
+++ b/src/TLS/protocol.cpp
@@ -37,7 +37,7 @@ using enum ContentType;
 
 TLS::TLS(std::unique_ptr<stream> output_stream) : m_client(std::move(output_stream) ) {}
 
-task<stream_result> TLS::read_append_common(std::vector<uint8_t>& data, std::optional<milliseconds> timeout, bool return_early) {
+task<stream_result> TLS::read_append_common(std::deque<uint8_t>& data, std::optional<milliseconds> timeout, bool return_early) {
     guard g { &m_async_read_mut };
     co_await m_async_read_mut.lock();
     auto initial_size = data.size();
@@ -52,7 +52,7 @@ task<stream_result> TLS::read_append_common(std::vector<uint8_t>& data, std::opt
         if(m_engine.m_expected_read_record == HandshakeStage::application_closed) {
             co_return stream_result::closed;
         }
-        std::vector<uint8_t> input_data;
+        std::deque<uint8_t> input_data;
         auto read_timeout = std::optional(project_options.handshake_timeout);
         if(m_engine.m_expected_read_record == HandshakeStage::application_data) {
             read_timeout = timeout;
@@ -82,7 +82,7 @@ task<stream_result> TLS::await_message(HandshakeStage stage) {
         if(m_engine.m_expected_read_record > stage) {
             co_return stream_result::ok;
         }
-        std::vector<uint8_t> input_data;
+        std::deque<uint8_t> input_data;
         auto read_res = co_await m_client->read_append(input_data, project_options.handshake_timeout);
         if(read_res != stream_result::ok) {
             co_return read_res;
@@ -95,11 +95,11 @@ task<stream_result> TLS::await_message(HandshakeStage stage) {
     }
 }
 
-task<stream_result> TLS::read_append(std::vector<uint8_t>& data, std::optional<milliseconds> timeout) {
+task<stream_result> TLS::read_append(std::deque<uint8_t>& data, std::optional<milliseconds> timeout) {
     return read_append_common(data, timeout, false);
 }
 
-task<stream_result> TLS::read_append_early_data(std::vector<uint8_t>& data, std::optional<milliseconds> timeout) {
+task<stream_result> TLS::read_append_early_data(std::deque<uint8_t>& data, std::optional<milliseconds> timeout) {
     return read_append_common(data, timeout, true);
 }
 
@@ -155,7 +155,7 @@ task<void> TLS::close_notify() {
     guard g { &m_async_read_mut };
     co_await m_async_read_mut.lock();
     do {
-        std::vector<uint8_t> input_data;
+        std::deque<uint8_t> input_data;
         if(m_engine.m_expected_read_record == HandshakeStage::application_closed) {
             co_return;
         }

--- a/src/TLS/protocol.hpp
+++ b/src/TLS/protocol.hpp
@@ -61,7 +61,17 @@ private:
 
 tls_record server_key_update_record(KeyUpdateRequest req);
 
+class buffer {
+public:
+    std::deque<uint8_t> write(const std::span<const uint8_t> data);
+    std::deque<uint8_t> flush();
+private:
+    static constexpr size_t BUFFER_SIZE = 4096;
+    std::deque<uint8_t> m_buffer;
+};
+
 } // namespace
+
 
 
 #endif // tls_hpp

--- a/src/TLS/protocol.hpp
+++ b/src/TLS/protocol.hpp
@@ -61,6 +61,8 @@ private:
 
 tls_record server_key_update_record(KeyUpdateRequest req);
 
+// todo: writes to the TLS context should be buffered
+// flush if waiting for a WINDOW_UPDATE or about to block on read
 class buffer {
 public:
     std::deque<uint8_t> write(const std::span<const uint8_t> data);

--- a/src/TLS/protocol.hpp
+++ b/src/TLS/protocol.hpp
@@ -34,8 +34,8 @@ public:
     TLS(std::unique_ptr<stream> output_stream);
     ~TLS() = default;
     
-    [[nodiscard]] task<stream_result> read_append(std::vector<uint8_t>&, std::optional<milliseconds> timeout) override;
-    [[nodiscard]] task<stream_result> read_append_early_data(std::vector<uint8_t>&, std::optional<milliseconds> timeout);
+    [[nodiscard]] task<stream_result> read_append(std::deque<uint8_t>&, std::optional<milliseconds> timeout) override;
+    [[nodiscard]] task<stream_result> read_append_early_data(std::deque<uint8_t>&, std::optional<milliseconds> timeout);
     [[nodiscard]] task<stream_result> await_handshake_finished(); // call this after read_append_early_data for sensitive data
     [[nodiscard]] task<stream_result> write(std::vector<uint8_t>, std::optional<milliseconds> timeout) override;
     [[nodiscard]] task<void> close_notify() override;
@@ -51,10 +51,10 @@ private:
     async_mutex m_async_read_mut;
 
     std::queue<packet_timed> output;
-    std::vector<uint8_t> early_data_buffer;
+    std::deque<uint8_t> early_data_buffer;
 
     
-    task<stream_result> read_append_common(std::vector<uint8_t>& data, std::optional<milliseconds> timeout, bool return_early);
+    task<stream_result> read_append_common(std::deque<uint8_t>& data, std::optional<milliseconds> timeout, bool return_early);
     task<stream_result> net_write_all();
     task<stream_result> await_message(HandshakeStage stage);
 };

--- a/src/TLS/protocol.hpp
+++ b/src/TLS/protocol.hpp
@@ -34,10 +34,10 @@ public:
     TLS(std::unique_ptr<stream> output_stream);
     ~TLS() = default;
     
-    [[nodiscard]] task<stream_result> read_append(ustring&, std::optional<milliseconds> timeout) override;
-    [[nodiscard]] task<stream_result> read_append_early_data(ustring&, std::optional<milliseconds> timeout);
+    [[nodiscard]] task<stream_result> read_append(std::vector<uint8_t>&, std::optional<milliseconds> timeout) override;
+    [[nodiscard]] task<stream_result> read_append_early_data(std::vector<uint8_t>&, std::optional<milliseconds> timeout);
     [[nodiscard]] task<stream_result> await_handshake_finished(); // call this after read_append_early_data for sensitive data
-    [[nodiscard]] task<stream_result> write(ustring, std::optional<milliseconds> timeout) override;
+    [[nodiscard]] task<stream_result> write(std::vector<uint8_t>, std::optional<milliseconds> timeout) override;
     [[nodiscard]] task<void> close_notify() override;
     [[nodiscard]] task<stream_result> await_hello();
 
@@ -51,10 +51,10 @@ private:
     async_mutex m_async_read_mut;
 
     std::queue<packet_timed> output;
-    ustring early_data_buffer;
+    std::vector<uint8_t> early_data_buffer;
 
     
-    task<stream_result> read_append_common(ustring& data, std::optional<milliseconds> timeout, bool return_early);
+    task<stream_result> read_append_common(std::vector<uint8_t>& data, std::optional<milliseconds> timeout, bool return_early);
     task<stream_result> net_write_all();
     task<stream_result> await_message(HandshakeStage stage);
 };

--- a/src/TLS/protocol.hpp
+++ b/src/TLS/protocol.hpp
@@ -40,7 +40,6 @@ public:
     [[nodiscard]] task<stream_result> write(ustring, std::optional<milliseconds> timeout) override;
     [[nodiscard]] task<void> close_notify() override;
     [[nodiscard]] task<stream_result> await_hello();
-    [[nodiscard]] task<stream_result> flush() override;
 
     std::string alpn();
 

--- a/src/TLS/session_ticket.cpp
+++ b/src/TLS/session_ticket.cpp
@@ -27,9 +27,9 @@ ustring TLS13SessionTicket::serialise() {
     checked_bigend_write(sni.size(), out, 21, 1);
     checked_bigend_write(alpn.size(), out, 22, 1);
 
-    out.append(resumption_secret.begin(), resumption_secret.end());
-    out.append(sni.begin(), sni.end());
-    out.append(alpn.begin(), alpn.end());
+    out.insert(out.end(), resumption_secret.begin(), resumption_secret.end());
+    out.insert(out.end(), sni.begin(), sni.end());
+    out.insert(out.end(), alpn.begin(), alpn.end());
     return out;
 }
 
@@ -78,7 +78,7 @@ ustring encrypt_message(ustring plaintext, const std::array<uint8_t, 16>& encryp
         bytestream.squeeze(&c, 1);
         plaintext[i] ^= c;
     }
-    plaintext.append(number_once_bytes.begin(), number_once_bytes.end());
+    plaintext.insert(plaintext.end(), number_once_bytes.begin(), number_once_bytes.end());
 
     keccak_sponge macgen;
     macgen.absorb(encryption_key.data(), encryption_key.size());

--- a/src/TLS/session_ticket.cpp
+++ b/src/TLS/session_ticket.cpp
@@ -9,9 +9,9 @@ namespace fbw {
 
 std::array<uint8_t, 16> session_ticket_master_secret {};
 
-ustring TLS13SessionTicket::serialise() {
+std::vector<uint8_t> TLS13SessionTicket::serialise() {
     constexpr int header_size = 23;
-    ustring out;
+    std::vector<uint8_t> out;
     out.reserve(header_size + resumption_secret.size() + sni.size() + alpn.size() + 2);
     out.resize(header_size);
     checked_bigend_write(version, out, 0, 2);
@@ -33,7 +33,7 @@ ustring TLS13SessionTicket::serialise() {
     return out;
 }
 
-std::optional<TLS13SessionTicket> TLS13SessionTicket::deserialise(ustring ticket) {
+std::optional<TLS13SessionTicket> TLS13SessionTicket::deserialise(std::vector<uint8_t> ticket) {
     constexpr size_t header_size = 23;
 
     if(ticket.size() < header_size) {
@@ -62,7 +62,7 @@ std::optional<TLS13SessionTicket> TLS13SessionTicket::deserialise(ustring ticket
     return out;
 }
 
-ustring encrypt_message(ustring plaintext, const std::array<uint8_t, 16>& encryption_key, uint64_t number_once) {
+std::vector<uint8_t> encrypt_message(std::vector<uint8_t> plaintext, const std::array<uint8_t, 16>& encryption_key, uint64_t number_once) {
     constexpr size_t number_once_size = 8;
     constexpr size_t mac_size = 16;
     std::array<uint8_t, number_once_size> number_once_bytes;
@@ -89,7 +89,7 @@ ustring encrypt_message(ustring plaintext, const std::array<uint8_t, 16>& encryp
     return plaintext;
 }
 
-std::optional<std::pair<ustring, uint64_t>> decrypt_message(ustring ciphertext, const std::array<uint8_t, 16>& encryption_key) {
+std::optional<std::pair<std::vector<uint8_t>, uint64_t>> decrypt_message(std::vector<uint8_t> ciphertext, const std::array<uint8_t, 16>& encryption_key) {
     constexpr size_t number_once_size = 8;
     constexpr size_t mac_size = 16;
     if(ciphertext.size() < (number_once_size + mac_size)) {
@@ -123,12 +123,12 @@ std::optional<std::pair<ustring, uint64_t>> decrypt_message(ustring ciphertext, 
     return {{ std::move(ciphertext), number_once }};
 }
 
-ustring TLS13SessionTicket::encrypt_ticket(const std::array<uint8_t, 16>& encryption_key, uint64_t number_once) {
+std::vector<uint8_t> TLS13SessionTicket::encrypt_ticket(const std::array<uint8_t, 16>& encryption_key, uint64_t number_once) {
     auto plaintext = serialise();
     return encrypt_message(std::move(plaintext), encryption_key, number_once);
 }
 
-std::optional<TLS13SessionTicket> TLS13SessionTicket::decrypt_ticket(ustring ticket, const std::array<uint8_t, 16>& encryption_key) {
+std::optional<TLS13SessionTicket> TLS13SessionTicket::decrypt_ticket(std::vector<uint8_t> ticket, const std::array<uint8_t, 16>& encryption_key) {
     auto opt_ticket_bytes_number_once = decrypt_message(ticket, encryption_key);
     if(!opt_ticket_bytes_number_once) {
         return std::nullopt;
@@ -177,7 +177,7 @@ std::optional<tls_record> TLS13SessionTicket::server_session_ticket_record(TLS13
     record.end_size_header();
 
     record.start_size_header(2);
-    ustring session_ticket_bytes = ticket.encrypt_ticket(encryption_key, number_once);
+    std::vector<uint8_t> session_ticket_bytes = ticket.encrypt_ticket(encryption_key, number_once);
     record.write(session_ticket_bytes);
     record.end_size_header();
 

--- a/src/TLS/session_ticket.hpp
+++ b/src/TLS/session_ticket.hpp
@@ -32,17 +32,17 @@ struct TLS13SessionTicket {
     cipher_suites cipher_suite;
     bool  early_data_allowed;
     uint64_t number_once;
-    ustring resumption_secret;
+    std::vector<uint8_t> resumption_secret;
     std::string sni;
     std::string alpn;
     
-    static std::optional<TLS13SessionTicket> decrypt_ticket(ustring ticket, const std::array<uint8_t, 16>& encryption_key);
+    static std::optional<TLS13SessionTicket> decrypt_ticket(std::vector<uint8_t> ticket, const std::array<uint8_t, 16>& encryption_key);
     static std::optional<tls_record> server_session_ticket_record(TLS13SessionTicket ticket, std::array<uint8_t, 16> encryption_key, uint64_t number_once);
 
 private:
-    ustring encrypt_ticket(const std::array<uint8_t, 16>& encryption_key, uint64_t number_once);
-    ustring serialise();
-    static std::optional<TLS13SessionTicket> deserialise(ustring ticket);
+    std::vector<uint8_t> encrypt_ticket(const std::array<uint8_t, 16>& encryption_key, uint64_t number_once);
+    std::vector<uint8_t> serialise();
+    static std::optional<TLS13SessionTicket> deserialise(std::vector<uint8_t> ticket);
 };
 
 void write_early_data_ticket_ext(tls_record& record);

--- a/src/TLS/tls_engine.cpp
+++ b/src/TLS/tls_engine.cpp
@@ -49,7 +49,7 @@ std::string tls_engine::alpn() {
     return handshake.alpn;
 }
 
-HandshakeStage tls_engine::process_net_read(std::queue<packet_timed>& network_output, std::vector<uint8_t>& application_data, const std::vector<uint8_t>& bio_input, std::optional<milliseconds> app_timeout) {
+HandshakeStage tls_engine::process_net_read(std::queue<packet_timed>& network_output, std::deque<uint8_t>& application_data, const std::deque<uint8_t>& bio_input, std::optional<milliseconds> app_timeout) {
     try {
         if(m_expected_read_record == HandshakeStage::application_data or m_expected_read_record == HandshakeStage::client_early_data) {
             std::scoped_lock lk { m_write_queue_mut };
@@ -641,7 +641,7 @@ void tls_engine::process_close_notify(std::queue<packet_timed>& output) {
     server_alert_sync(output, AlertLevel::warning, AlertDescription::close_notify);
 }
 
-stream_result tls_engine::close_notify_finish(const std::vector<uint8_t>& bio_input) {
+stream_result tls_engine::close_notify_finish(const std::deque<uint8_t>& bio_input) {
     m_buffer.insert(m_buffer.end(), bio_input.begin(), bio_input.end());
     auto opt_record = pop_record_from_buffer();
     if(!opt_record) {

--- a/src/TLS/tls_engine.hpp
+++ b/src/TLS/tls_engine.hpp
@@ -35,12 +35,12 @@ class tls_engine {
 public:
     tls_engine();
 
-    HandshakeStage process_net_read(std::queue<packet_timed>& network_output, std::vector<uint8_t>& application_data, const std::vector<uint8_t>& bio_input, std::optional<milliseconds> app_timeout);
+    HandshakeStage process_net_read(std::queue<packet_timed>& network_output, std::deque<uint8_t>& application_data, const std::deque<uint8_t>& bio_input, std::optional<milliseconds> app_timeout);
     
     stream_result process_net_write(std::queue<packet_timed>& output, std::vector<uint8_t> data, std::optional<milliseconds> timeout);
 
     void process_close_notify(std::queue<packet_timed>& output);
-    stream_result close_notify_finish(const std::vector<uint8_t>& bio_input);
+    stream_result close_notify_finish(const std::deque<uint8_t>& bio_input);
 
     std::string alpn();
     

--- a/src/TLS/tls_engine.hpp
+++ b/src/TLS/tls_engine.hpp
@@ -26,7 +26,7 @@
 namespace fbw {
 
 struct packet_timed  {
-    ustring data;
+    std::vector<uint8_t> data;
     std::optional<milliseconds> timeout;
 };
 
@@ -35,12 +35,12 @@ class tls_engine {
 public:
     tls_engine();
 
-    HandshakeStage process_net_read(std::queue<packet_timed>& network_output, ustring& application_data, const ustring& bio_input, std::optional<milliseconds> app_timeout);
+    HandshakeStage process_net_read(std::queue<packet_timed>& network_output, std::vector<uint8_t>& application_data, const std::vector<uint8_t>& bio_input, std::optional<milliseconds> app_timeout);
     
-    stream_result process_net_write(std::queue<packet_timed>& output, ustring data, std::optional<milliseconds> timeout);
+    stream_result process_net_write(std::queue<packet_timed>& output, std::vector<uint8_t> data, std::optional<milliseconds> timeout);
 
     void process_close_notify(std::queue<packet_timed>& output);
-    stream_result close_notify_finish(const ustring& bio_input);
+    stream_result close_notify_finish(const std::vector<uint8_t>& bio_input);
 
     std::string alpn();
     
@@ -55,23 +55,23 @@ private:
     bool can_heartbeat = false;
     uint16_t tls_protocol_version = 0;
     std::optional<std::array<uint8_t, 32>> tls13_x25519_key;
-    ustring m_handshake_fragment {};
+    std::vector<uint8_t> m_handshake_fragment {};
     
     uint32_t early_data_received = 0;
-    ustring m_buffer;
+    std::vector<uint8_t> m_buffer;
     bool write_connection_done = false;
 
     [[nodiscard]] tls_record decrypt_record(tls_record);
 
     void client_handshake_record_sync(std::queue<packet_timed>& output, tls_record record);
-    void client_handshake_message_sync(std::queue<packet_timed>& output, const ustring& handshake_message);
+    void client_handshake_message_sync(std::queue<packet_timed>& output, const std::vector<uint8_t>& handshake_message);
     void client_alert_sync(std::queue<packet_timed>& output, tls_record record, std::optional<milliseconds> timeout);
     void client_heartbeat(std::queue<packet_timed>& output, tls_record client_record, std::optional<milliseconds> timeout);
-    void client_hello(const ustring& handshake_message);
-    void client_key_exchange(ustring key_exchange);
-    void client_handshake_finished12(const ustring& finish); 
-    void client_handshake_finished13(const ustring& finish);
-    void client_end_of_early_data(ustring handshake_message);
+    void client_hello(const std::vector<uint8_t>& handshake_message);
+    void client_key_exchange(std::vector<uint8_t> key_exchange);
+    void client_handshake_finished12(const std::vector<uint8_t>& finish); 
+    void client_handshake_finished13(const std::vector<uint8_t>& finish);
+    void client_end_of_early_data(std::vector<uint8_t> handshake_message);
     void client_change_cipher_spec(tls_record);
     
     void server_key_update_respond(std::queue<packet_timed>& output);
@@ -92,7 +92,7 @@ private:
     void update_sync(std::queue<packet_timed>& output);
     void write_record_sync(std::queue<packet_timed>& output, tls_record record, std::optional<milliseconds> timeout);
 
-    KeyUpdateRequest client_key_update_received(const ustring& handshake_message);
+    KeyUpdateRequest client_key_update_received(const std::vector<uint8_t>& handshake_message);
     static std::pair<bool, tls_record> client_heartbeat_record(tls_record record, bool can_heartbeat);
     std::optional<tls_record> pop_record_from_buffer();
 };

--- a/src/TLS/tls_engine.hpp
+++ b/src/TLS/tls_engine.hpp
@@ -38,7 +38,6 @@ public:
     HandshakeStage process_net_read(std::queue<packet_timed>& network_output, ustring& application_data, const ustring& bio_input, std::optional<milliseconds> app_timeout);
     
     stream_result process_net_write(std::queue<packet_timed>& output, ustring data, std::optional<milliseconds> timeout);
-    stream_result process_net_flush(std::queue<packet_timed>& output);
 
     void process_close_notify(std::queue<packet_timed>& output);
     stream_result close_notify_finish(const ustring& bio_input);
@@ -48,7 +47,6 @@ public:
     HandshakeStage m_expected_read_record = HandshakeStage::client_hello;
     std::mutex m_write_queue_mut;
 private:
-    std::deque<tls_record> write_buffer;
     handshake_ctx handshake;
 
     bool server_cipher_spec = false;
@@ -91,9 +89,8 @@ private:
     void server_session_ticket_sync(std::queue<packet_timed>& output);
     void server_alert_sync(std::queue<packet_timed>& output, AlertLevel level, AlertDescription description);
 
-    void flush_update_sync(std::queue<packet_timed>& output);
+    void update_sync(std::queue<packet_timed>& output);
     void write_record_sync(std::queue<packet_timed>& output, tls_record record, std::optional<milliseconds> timeout);
-    void flush_sync_internal(std::queue<packet_timed>&);
 
     KeyUpdateRequest client_key_update_received(const ustring& handshake_message);
     static std::pair<bool, tls_record> client_heartbeat_record(tls_record record, bool can_heartbeat);

--- a/src/global.hpp
+++ b/src/global.hpp
@@ -21,7 +21,7 @@
 
 namespace fbw {
 
-using ustring = std::basic_string<uint8_t>;
+using ustring = std::vector<uint8_t>;
 
 constexpr size_t TLS_RECORD_SIZE = (1u << 14);
 constexpr size_t TLS_EXPANSION_MAX = 2048;
@@ -95,7 +95,7 @@ inline void checked_bigend_write(uint64_t x, T& container, ssize_t idx, short nb
 
 [[nodiscard("returns unsigned string")]] inline ustring to_unsigned(std::string s) {
     ustring out;
-    out.append(s.cbegin(), s.cend());
+    out.assign(s.cbegin(), s.cend());
     return out;
 }
 

--- a/src/global.hpp
+++ b/src/global.hpp
@@ -21,7 +21,6 @@
 
 namespace fbw {
 
-using ustring = std::vector<uint8_t>;
 
 constexpr size_t TLS_RECORD_SIZE = (1u << 14);
 constexpr size_t TLS_EXPANSION_MAX = 2048;
@@ -93,13 +92,13 @@ inline void checked_bigend_write(uint64_t x, T& container, ssize_t idx, short nb
     }
 }
 
-[[nodiscard("returns unsigned string")]] inline ustring to_unsigned(std::string s) {
-    ustring out;
+[[nodiscard("returns unsigned string")]] inline std::vector<uint8_t> to_unsigned(std::string s) {
+    std::vector<uint8_t> out;
     out.assign(s.cbegin(), s.cend());
     return out;
 }
 
-[[nodiscard("returns signed string")]] inline std::string to_signed(ustring s) {
+[[nodiscard("returns signed string")]] inline std::string to_signed(std::vector<uint8_t> s) {
     std::string out;
     out.append(s.cbegin(), s.cend());
     return out;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -69,6 +69,8 @@
 // the h2_context should stream in bytes not frames, so that it can emit the right errors for malformed frames
 // and send the server settings straight after the client preface (which isn't a frame)
 
+// tls record serialisation could be simpler
+
 // for state machine transitions, have functions close_local() and close_remote() which perform some cleanup
 // go through RFC 9113 ensuring correct handling of everything
 
@@ -83,6 +85,8 @@
 // don't need multiple async layers for TLS + HTTP/2, combine
 
 // handle client sending HTTP request on HTTPS port
+
+// Post and range request handling for http/2 (video?)
 
 // check whether content-length is essential and debug accordingly
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -93,6 +93,10 @@
 
 // HTTP 406 content negotiation
 
+// request_headers struct rather than a vector.
+
+// buffered writes
+
 // POST request handling
 // after a connection is accepted, this is the per-client entry point
 task<void> http_client(std::unique_ptr<fbw::stream> client_stream, bool redirect, connection_token ip_connections, std::string alpn) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -65,6 +65,9 @@
 //      TLS Client
 //      Russian ciphers
 
+
+// Post and range request handling for http/2 (video?)
+
 // check std::span ownership soundness
 // the h2_context should stream in bytes not frames, so that it can emit the right errors for malformed frames
 // and send the server settings straight after the client preface (which isn't a frame)
@@ -76,17 +79,13 @@
 
 // write and use a 'safe add' function
 // rename stream_result enum to: ok, awaiting, timeout, fail
-// HTTP errors are getting thrown and not caught properly
 
 // better logic for deciding if a header should be indexed
-// after sending some data, we should yield to read some frames
 // test if our inbound hpack dynamic table is actually getting used
 
 // don't need multiple async layers for TLS + HTTP/2, combine
 
 // handle client sending HTTP request on HTTPS port
-
-// Post and range request handling for http/2 (video?)
 
 // check whether content-length is essential and debug accordingly
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -67,8 +67,9 @@
 
 
 // Post and range request handling for http/2 (video?)
+// something going wrong with HPACK for range requests
+// something maybe going wrong with 'new' HTTP/1.1 POST requests
 
-// check std::span ownership soundness
 // the h2_context should stream in bytes not frames, so that it can emit the right errors for malformed frames
 // and send the server settings straight after the client preface (which isn't a frame)
 
@@ -85,7 +86,8 @@
 // rename stream_result enum to: ok, awaiting, timeout, fail
 
 // better logic for deciding if a header should be indexed
-// test if our inbound hpack dynamic table is actually getting used
+
+// implement http/2 graceful server shutdown
 
 // don't need multiple async layers for TLS + HTTP/2, combine
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -38,6 +38,7 @@
 //      Check ALPN in session tickets
 //      g++-14-arm-linux-gnueabihf is only on trixie
 //      use std::exchange instead of std::move
+//      confirm no reference cycles that keep h2 connections alive
 
 // Syntax:
 //      Add 'explict' to constructors
@@ -63,6 +64,11 @@
 //      QUIC
 //      TLS Client
 //      Russian ciphers
+
+
+// check if coroutine handle actually sends data after sending data, or tries to reloop until a window update?
+// data could be getting lost if a std::span is bad?
+
 
 // after a connection is accepted, this is the per-client entry point
 task<void> http_client(std::unique_ptr<fbw::stream> client_stream, bool redirect, connection_token ip_connections, std::string alpn) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -69,18 +69,30 @@
 // the h2_context should stream in bytes not frames, so that it can emit the right errors for malformed frames
 // and send the server settings straight after the client preface (which isn't a frame)
 
-// write a 'round-trip detector' to determine when to we can delete old streams -
-// i.e. if we send an END_STREAM and then send a record after that which requires an ACK, then that client ACK tells that the client
-// has received the END_STREAM
+// replace vectors with deques for buffers
+
 // for state machine transitions, have functions close_local() and close_remote() which perform some cleanup
 // go through RFC 9113 ensuring correct handling of everything
 
 // write and use a 'safe add' function
-
-// something is going wrong with HPACK or outbound header parsing in some way?
-
 // rename stream_result enum to: ok, awaiting, timeout, fail
+// HTTP errors are getting thrown and not caught properly
 
+// better logic for deciding if a header should be indexed
+// after sending some data, we should yield to read some frames
+// test if our inbound hpack dynamic table is actually getting used
+
+// don't need multiple async layers for TLS + HTTP/2, combine
+
+// handle client sending HTTP request on HTTPS port
+
+// check whether content-length is essential and debug accordingly
+
+// pass everything by span
+
+// HTTP 406 content negotiation
+
+// POST request handling
 // after a connection is accepted, this is the per-client entry point
 task<void> http_client(std::unique_ptr<fbw::stream> client_stream, bool redirect, connection_token ip_connections, std::string alpn) {
     try {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -69,8 +69,6 @@
 // the h2_context should stream in bytes not frames, so that it can emit the right errors for malformed frames
 // and send the server settings straight after the client preface (which isn't a frame)
 
-// replace vectors with deques for buffers
-
 // for state machine transitions, have functions close_local() and close_remote() which perform some cleanup
 // go through RFC 9113 ensuring correct handling of everything
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -74,6 +74,10 @@
 
 // tls record serialisation could be simpler
 
+// check multithreading still works
+// check all ciphers still work
+// check if key rotation still works
+
 // for state machine transitions, have functions close_local() and close_remote() which perform some cleanup
 // go through RFC 9113 ensuring correct handling of everything
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -32,6 +32,7 @@
 //      HTTP/2
 //      HTTP webroot for ACME
 //      HRR cookies
+//      HTTP/2 Timeouts
 
 // Correctness:
 //      Check that poly1305 is constant-time
@@ -39,6 +40,7 @@
 //      ustring is not UB but can be
 //      Check ALPN in session tickets
 //      g++-14-arm-linux-gnueabihf is only on trixie
+//      use std::exchange instead of std::move
 
 // Syntax:
 //      Add 'explict' to constructors

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -65,10 +65,21 @@
 //      TLS Client
 //      Russian ciphers
 
+// check std::span ownership soundness
+// the h2_context should stream in bytes not frames, so that it can emit the right errors for malformed frames
+// and send the server settings straight after the client preface (which isn't a frame)
 
-// check if coroutine handle actually sends data after sending data, or tries to reloop until a window update?
-// data could be getting lost if a std::span is bad?
+// write a 'round-trip detector' to determine when to we can delete old streams -
+// i.e. if we send an END_STREAM and then send a record after that which requires an ACK, then that client ACK tells that the client
+// has received the END_STREAM
+// for state machine transitions, have functions close_local() and close_remote() which perform some cleanup
+// go through RFC 9113 ensuring correct handling of everything
 
+// write and use a 'safe add' function
+
+// something is going wrong with HPACK or outbound header parsing in some way?
+
+// rename stream_result enum to: ok, awaiting, timeout, fail
 
 // after a connection is accepted, this is the per-client entry point
 task<void> http_client(std::unique_ptr<fbw::stream> client_stream, bool redirect, connection_token ip_connections, std::string alpn) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -34,7 +34,7 @@
 // Correctness:
 //      Check that poly1305 is constant-time
 //      Points at infinity?
-//      ustring is not UB but can be
+//      std::vector<uint8_t> is not UB but can be
 //      Check ALPN in session tickets
 //      g++-14-arm-linux-gnueabihf is only on trixie
 //      use std::exchange instead of std::move


### PR DESCRIPTION
Refactored HTTP/1.1 layer
Sorted out a bug in the HTTP/2 frame receipt logic where frames were getting lost
Bug in CI where tokens weren't getting generated
Almost got HTTP/2 working but still some HPACK bug
Solved UB issue with basic_string<uint8_t> being undefined
Added more to the to-do list